### PR TITLE
Main PLL clock implementation for STM32F4xx

### DIFF
--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -288,6 +288,7 @@ unsafe fn create_peripherals() -> (
 ) {
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f429zi::rcc::Rcc, stm32f429zi::rcc::Rcc::new());
+
     let syscfg = static_init!(
         stm32f429zi::syscfg::Syscfg,
         stm32f429zi::syscfg::Syscfg::new(rcc)

--- a/boards/weact_f401ccu6/layout.ld
+++ b/boards/weact_f401ccu6/layout.ld
@@ -1,13 +1,13 @@
 /* Memory layout for the STM32F401CCU6
- * rom = 256KB (LENGTH = 0x00040000)
- * kernel = 128KB
- * user = 128KB
- * ram = 64KB */
+ * rom = 256KiB (LENGTH = 0x00040000)
+ * kernel = 150KiB
+ * user = 102KiB
+ * ram = 64KiB */
 
 MEMORY
 {
-  rom (rx)  : ORIGIN = 0x08000000, LENGTH = 0x00020000
-  prog (rx) : ORIGIN = 0x08020000, LENGTH = 0x00020000
+  rom (rx)  : ORIGIN = 0x08000000, LENGTH = 150K
+  prog (rx) : ORIGIN = 0x08025800, LENGTH = 102K
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
 }
 

--- a/chips/stm32f401cc/Cargo.toml
+++ b/chips/stm32f401cc/Cargo.toml
@@ -7,5 +7,8 @@ edition.workspace = true
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
-stm32f4xx = { path = "../stm32f4xx" }
 enum_primitive = { path = "../../libraries/enum_primitive" }
+
+[dependencies.stm32f4xx]
+path = "../stm32f4xx"
+features = ["stm32f401"]

--- a/chips/stm32f412g/Cargo.toml
+++ b/chips/stm32f412g/Cargo.toml
@@ -7,5 +7,8 @@ edition.workspace = true
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
-stm32f4xx = { path = "../stm32f4xx" }
 enum_primitive = { path = "../../libraries/enum_primitive" }
+
+[dependencies.stm32f4xx]
+path = "../stm32f4xx"
+features = ["stm32f412"]

--- a/chips/stm32f429zi/Cargo.toml
+++ b/chips/stm32f429zi/Cargo.toml
@@ -7,5 +7,8 @@ edition.workspace = true
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
-stm32f4xx = { path = "../stm32f4xx" }
 enum_primitive = { path = "../../libraries/enum_primitive" }
+
+[dependencies.stm32f4xx]
+path = "../stm32f4xx"
+features = ["stm32f429"]

--- a/chips/stm32f429zi/src/lib.rs
+++ b/chips/stm32f429zi/src/lib.rs
@@ -3,7 +3,7 @@
 use cortexm4::{CortexM4, CortexMVariant};
 
 pub use stm32f4xx::{
-    adc, can, chip, dbg, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, trng, usart,
+    adc, can, chip, dbg, dma, exti, gpio, nvic, pll, rcc, spi, syscfg, tim2, trng, usart,
 };
 
 pub mod can_registers;

--- a/chips/stm32f446re/Cargo.toml
+++ b/chips/stm32f446re/Cargo.toml
@@ -7,5 +7,8 @@ edition.workspace = true
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
-stm32f4xx = { path = "../stm32f4xx" }
 enum_primitive = { path = "../../libraries/enum_primitive" }
+
+[dependencies.stm32f4xx]
+path = "../stm32f4xx"
+features = ["stm32f446"]

--- a/chips/stm32f4xx/Cargo.toml
+++ b/chips/stm32f4xx/Cargo.toml
@@ -8,3 +8,11 @@ edition.workspace = true
 cortexm4 = { path = "../../arch/cortex-m4" }
 enum_primitive = { path = "../../libraries/enum_primitive" }
 kernel = { path = "../../kernel" }
+
+[features]
+default = []
+
+stm32f401 = []
+stm32f412 = []
+stm32f429 = []
+stm32f446 = []

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -23,6 +23,7 @@ pub struct Stm32f4xxDefaultPeripherals<'a> {
     pub dma2_streams: [crate::dma::Stream<'a, dma::Dma2<'a>>; 8],
     pub exti: &'a crate::exti::Exti<'a>,
     pub i2c1: crate::i2c::I2C<'a>,
+    pub pll: crate::pll::Pll<'a>,
     pub spi3: crate::spi::Spi<'a>,
     pub tim2: crate::tim2::Tim2<'a>,
     pub usart1: crate::usart::Usart<'a, dma::Dma2<'a>>,
@@ -45,6 +46,7 @@ impl<'a> Stm32f4xxDefaultPeripherals<'a> {
             dma2_streams: dma::new_dma2_stream(dma2),
             exti,
             i2c1: crate::i2c::I2C::new(rcc),
+            pll: crate::pll::Pll::new(rcc),
             spi3: crate::spi::Spi::new(
                 crate::spi::SPI3_BASE,
                 crate::spi::SpiClock(crate::rcc::PeripheralClock::new(

--- a/chips/stm32f4xx/src/lib.rs
+++ b/chips/stm32f4xx/src/lib.rs
@@ -19,6 +19,7 @@ pub mod exti;
 pub mod fsmc;
 pub mod gpio;
 pub mod i2c;
+pub mod pll;
 pub mod rcc;
 pub mod spi;
 pub mod syscfg;

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -41,7 +41,7 @@
 //! ```
 //!
 //! ## Check the clock frequency
-//! 
+//!
 //! ```rust,ignore
 //! let optional_pll_frequency = pll.get_frequency();
 //! if let None = optional_pll_frequency {
@@ -98,7 +98,7 @@
 //! if let None = optional_pll48_frequency {
 //!     /* Clock stopped */
 //! }
-//! let pll48_frequency = optinal_pll48_frequency.unwrap_or_panic();
+//! let pll48_frequency = optional_pll48_frequency.unwrap_or_panic();
 //! ```
 
 

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -1,4 +1,4 @@
-#![warn(missing_docs)]
+#![deny(missing_docs)]
 //! Main phase-locked loop (PLL) clock driver for the STM32F4xx family. [^doc_ref]
 //!
 //! Many boards of the STM32F4xx family provide several PLL clocks. However, all of them have a

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -307,17 +307,26 @@ pub mod unit_tests {
         // 25MHz --> minimum required value for Ethernet devices
         assert_eq!((100 * MULTIPLIER, PLLP::DivideBy8), Pll::get_pll_config_for_frequency_using_hsi(25).unwrap());
 
+        // 54MHz --> last frequency before PLLP becomes DivideBy6
+        assert_eq!((216 * MULTIPLIER, PLLP::DivideBy8), Pll::get_pll_config_for_frequency_using_hsi(54).unwrap());
+
         // 55MHz --> PLLP becomes DivideBy6
         assert_eq!((165 * MULTIPLIER, PLLP::DivideBy6), Pll::get_pll_config_for_frequency_using_hsi(55).unwrap());
 
         // 70MHz --> Another value for PLLP::DivideBy6
         assert_eq!((210 * MULTIPLIER, PLLP::DivideBy6), Pll::get_pll_config_for_frequency_using_hsi(70).unwrap());
 
+        // 72MHz --> last frequency before PLLP becomes DivideBy4
+        assert_eq!((216 * MULTIPLIER, PLLP::DivideBy6), Pll::get_pll_config_for_frequency_using_hsi(72).unwrap());
+
         // 73MHz --> PLLP becomes DivideBy4
         assert_eq!((146 * MULTIPLIER, PLLP::DivideBy4), Pll::get_pll_config_for_frequency_using_hsi(73).unwrap());
 
         // 100MHz --> Another value for PLLP::DivideBy4
         assert_eq!((200 * MULTIPLIER, PLLP::DivideBy4), Pll::get_pll_config_for_frequency_using_hsi(100).unwrap());
+
+        // 108MHz --> last frequency before PLLP becomes DivideBy2
+        assert_eq!((216 * MULTIPLIER, PLLP::DivideBy4), Pll::get_pll_config_for_frequency_using_hsi(108).unwrap());
 
         // 109MHz --> PLLP becomes DivideBy2
         assert_eq!((109 * MULTIPLIER, PLLP::DivideBy2), Pll::get_pll_config_for_frequency_using_hsi(109).unwrap());

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -118,6 +118,8 @@ pub struct Pll<'a> {
     pll48_calibrated: OptionalCell<bool>,
 }
 
+const HSI_FREQUENCY_MHZ: usize = 16;
+
 impl<'a> Pll<'a> {
     // Create a new instance of the PLL clock.
     //
@@ -142,8 +144,8 @@ impl<'a> Pll<'a> {
         const PLLQ: usize = DEFAULT_PLLQ_VALUE as usize;
         Self {
             rcc,
-            frequency: OptionalCell::new(16 / PLLM * DEFAULT_PLLN_VALUE / PLLP),
-            pll48_frequency: OptionalCell::new(16 / PLLM * DEFAULT_PLLN_VALUE / PLLQ),
+            frequency: OptionalCell::new(HSI_FREQUENCY_MHZ / PLLM * DEFAULT_PLLN_VALUE / PLLP),
+            pll48_frequency: OptionalCell::new(HSI_FREQUENCY_MHZ / PLLM * DEFAULT_PLLN_VALUE / PLLQ),
             pll48_calibrated: OptionalCell::new(true),
         }
     }
@@ -165,7 +167,7 @@ impl<'a> Pll<'a> {
     // The caller must ensure the desired frequency lies between 13 and 216MHz. Otherwise, the
     // return value makes no sense.
     fn compute_plln(desired_frequency_mhz: usize, pllp: PLLP) -> usize {
-        const VCO_INPUT_FREQUENCY: usize = 16 / DEFAULT_PLLM_VALUE as usize;
+        const VCO_INPUT_FREQUENCY: usize = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize;
         desired_frequency_mhz * (pllp as usize + 1) * 2 / VCO_INPUT_FREQUENCY
     }
 
@@ -289,7 +291,7 @@ impl<'a> Pll<'a> {
         self.rcc.set_pll_clock_n_multiplier(plln);
 
         // Compute PLLQ
-        let vco_output_frequency = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        let vco_output_frequency = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         let pllq = Self::compute_pllq(vco_output_frequency);
         self.rcc.set_pll_clock_q_divider(pllq);
 
@@ -417,7 +419,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy8, pllp);
         let mut plln = Pll::compute_plln(13, pllp);
         assert_eq!(52 * MULTIPLIER, plln);
-        let mut vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        let mut vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         let mut pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy3, pllq);
 
@@ -426,7 +428,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy8, pllp);
         plln = Pll::compute_plln(25, pllp);
         assert_eq!(100 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy5, pllq);
 
@@ -435,7 +437,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy8, pllp);
         plln = Pll::compute_plln(54, pllp);
         assert_eq!(216 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy9, pllq);
 
@@ -444,7 +446,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy6, pllp);
         plln = Pll::compute_plln(55, pllp);
         assert_eq!(165 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy7, pllq);
 
@@ -453,7 +455,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy6, pllp);
         plln = Pll::compute_plln(70, pllp);
         assert_eq!(210 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy9, pllq);
 
@@ -462,7 +464,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy6, pllp);
         plln = Pll::compute_plln(72, pllp);
         assert_eq!(216 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy9, pllq);
 
@@ -471,7 +473,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy4, pllp);
         plln = Pll::compute_plln(73, pllp);
         assert_eq!(146 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy7, pllq);
 
@@ -480,7 +482,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy4, pllp);
         plln = Pll::compute_plln(100, pllp);
         assert_eq!(200 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy9, pllq);
 
@@ -489,7 +491,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy4, pllp);
         plln = Pll::compute_plln(108, pllp);
         assert_eq!(216 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy9, pllq);
 
@@ -498,7 +500,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy2, pllp);
         plln = Pll::compute_plln(109, pllp);
         assert_eq!(109 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy5, pllq);
 
@@ -507,7 +509,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy2, pllp);
         plln = Pll::compute_plln(125, pllp);
         assert_eq!(125 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy6, pllq);
 
@@ -516,7 +518,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy2, pllp);
         plln = Pll::compute_plln(180, pllp);
         assert_eq!(180 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy8, pllq);
 
@@ -525,7 +527,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy2, pllp);
         plln = Pll::compute_plln(216, pllp);
         assert_eq!(216 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
+        vco_output_frequency_mhz = HSI_FREQUENCY_MHZ / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy9, pllq);
 

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -185,7 +185,15 @@ impl<'a> Pll<'a> {
     fn compute_pllq(vco_output_frequency_mhz: usize) -> PLLQ {
         for pllq in 3..10 {
             if 48 * pllq >= vco_output_frequency_mhz {
-                return PLLQ::try_from(pllq).unwrap();
+                return match pllq {
+                    3 => PLLQ::DivideBy3,
+                    4 => PLLQ::DivideBy4,
+                    5 => PLLQ::DivideBy5,
+                    6 => PLLQ::DivideBy6,
+                    7 => PLLQ::DivideBy7,
+                    8 => PLLQ::DivideBy8,
+                    _ => PLLQ::DivideBy9,
+                };
             }
         }
         unreachable!("The previous for loop should always return");

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -40,29 +40,10 @@
 //! pll.enable();
 //! ```
 //!
-//! ## Check the clock frequency
-//!
-//! ```rust,ignore
-//! let optional_pll_frequency = pll.get_frequency();
-//! if let None = optional_pll_frequency {
-//!     /* Clock stopped */
-//! }
-//! let pll_frequency = optional_pll_frequency.unwrap();
-//! /* Computations based on the PLL frequency */
-//! ```
-//!
 //! ## Stop the clock
 //!
 //! ```rust,ignore
 //! pll.disable();
-//! ```
-//!
-//! ## Reconfigure the clock once started
-//!
-//! ```rust,ignore
-//! pll.disable(); // The PLL clock can't be configured while running
-//! pll.set_frequency(50); // 50MHz
-//! pll.enable();
 //! ```
 //!
 //! ## Check whether the PLL clock is running or not
@@ -74,14 +55,31 @@
 //! }
 //! ```
 //!
+//! ## Check the clock frequency
+//!
+//! ```rust,ignore
+//! let optional_pll_frequency = pll.get_frequency();
+//! if let None = optional_pll_frequency {
+//!     /* Clock stopped */
+//! }
+//! let pll_frequency = optional_pll_frequency.unwrap();
+//! /* Computations based on the PLL frequency */
+//! ```
+//!
+//! ## Reconfigure the clock once started
+//!
+//! ```rust,ignore
+//! pll.disable(); // The PLL clock can't be configured while running
+//! pll.set_frequency(50); // 50MHz
+//! pll.enable();
+//! ```
+//!
 //! ## Configure the PLL clock so that PLL48CLK output is correctly calibrated
 //! ```rust,ignore
 //! // The frequency of the PLL clock must be 1, 1.5, 2, 2.5, 3, 3.5 or 4 x 48MHz in order to get
-//! // 48MHz output. Otherwise, the driver will attempt to get a frequency lower than 48MHz, but as
-//! // close as possible to 48MHz.
+//! // 48MHz output. Otherwise, the driver will attempt to get the closest frequency lower than 48MHz
 //! pll.set_frequency(72); // 72MHz = 48Mhz * 1.5
 //! pll.enable();
-//! assert_eq!(true, pll.is_pll48_calibrated());
 //! ```
 //!
 //! ## Check if the PLL48CLK output is calibrated.

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -18,7 +18,7 @@
 //!
 //! # Examples
 //!
-//! For the purposes of brievity, any error checking has been removed. In real applications, always
+//! For the purposes of brevity, any error checking has been removed. In real applications, always
 //! check the return values of the [Pll] methods.
 //!
 //! First, get a reference to the [Pll] struct:
@@ -29,7 +29,7 @@
 //! ## Start the clock with a given frequency
 //!
 //! ```rust,ignore
-//! pll.set_frequency(100); // 100Mhz
+//! pll.set_frequency(100); // 100MHz
 //! pll.enable();
 //! ```
 //!
@@ -80,7 +80,7 @@ impl<'a> Pll<'a> {
     // The instance of the PLL clock is configured to run at 96MHz and with minimal PLL jitter
     // effects.
     //
-    // # Params
+    // # Parameters
     //
     // + rcc: an instance of [crate::rcc]
     //
@@ -132,7 +132,7 @@ impl<'a> Pll<'a> {
     ///
     /// + Err([ErrorCode::BUSY]): if enabling the PLL clock took too long. Recall this method to 
     /// ensure the PLL clock is running.
-    /// + Ok(()): PLL clock succesfully enabled and running.
+    /// + Ok(()): PLL clock successfully enabled and running.
     pub fn enable(&self) -> Result<(), ErrorCode> {
         // Enable the PLL clock
         self.rcc.enable_pll_clock();
@@ -199,7 +199,7 @@ impl<'a> Pll<'a> {
     /// + Err([ErrorCode::INVAL]): if the desired frequency can't be achieved
     /// + Err([ErrorCode::FAIL]): if the PLL clock is already enabled. It must be disabled before
     /// configuring it.
-    /// + Ok(()): the PLL clock has been succesfully configured
+    /// + Ok(()): the PLL clock has been successfully configured
     pub fn set_frequency(&self, desired_frequency_mhz: usize) -> Result<(), ErrorCode> {
         // Check whether the PLL clock is running or not
         if self.rcc.is_enabled_pll_clock() {

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -94,10 +94,7 @@ impl<'a> Pll<'a> {
             PLLP::DivideBy6 => 6,
             PLLP::DivideBy8 => 8,
         };
-        const PLLM: usize = match DEFAULT_PLLM_VALUE {
-            PLLM::DivideBy8 => 8,
-            PLLM::DivideBy16 => 16,
-        };
+        const PLLM: usize = DEFAULT_PLLM_VALUE as usize;
         Self {
             rcc,
             frequency: OptionalCell::new(16 / PLLM * DEFAULT_PLLN_VALUE / PLLP),

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -145,7 +145,9 @@ impl<'a> Pll<'a> {
         Self {
             rcc,
             frequency: OptionalCell::new(HSI_FREQUENCY_MHZ / PLLM * DEFAULT_PLLN_VALUE / PLLP),
-            pll48_frequency: OptionalCell::new(HSI_FREQUENCY_MHZ / PLLM * DEFAULT_PLLN_VALUE / PLLQ),
+            pll48_frequency: OptionalCell::new(
+                HSI_FREQUENCY_MHZ / PLLM * DEFAULT_PLLN_VALUE / PLLQ,
+            ),
             pll48_calibrated: OptionalCell::new(true),
         }
     }

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -103,13 +103,14 @@
 //!
 //! [^doc_ref]: See 6.2.3 in the documentation.
 
-
-use crate::rcc::*;
+use crate::rcc::{DEFAULT_PLLM_VALUE, DEFAULT_PLLN_VALUE, DEFAULT_PLLP_VALUE, DEFAULT_PLLQ_VALUE};
+use crate::rcc::{PLLM, PLLP, PLLQ};
+use crate::rcc::Rcc;
+use crate::rcc::SysClockSource;
 
 use kernel::debug;
-use kernel::ErrorCode;
 use kernel::utilities::cells::OptionalCell;
-
+use kernel::ErrorCode;
 
 /// Main PLL clock structure.
 pub struct Pll<'a> {
@@ -185,7 +186,7 @@ impl<'a> Pll<'a> {
     ///
     /// # Returns
     ///
-    /// + [Err]\([ErrorCode::BUSY]\): if enabling the PLL clock took too long. Recall this method to 
+    /// + [Err]\([ErrorCode::BUSY]\): if enabling the PLL clock took too long. Recall this method to
     /// ensure the PLL clock is running.
     /// + [Ok]\(()\): PLL clock successfully enabled and running.
     pub fn enable(&self) -> Result<(), ErrorCode> {
@@ -296,7 +297,8 @@ impl<'a> Pll<'a> {
 
         // Check if PLL48CLK is calibrated, e.g. its frequency is exactly 48MHz
         let pll48_frequency = vco_output_frequency / pllq as usize;
-        self.pll48_calibrated.set(pll48_frequency == 48 && vco_output_frequency % pllq as usize == 0);
+        self.pll48_calibrated
+            .set(pll48_frequency == 48 && vco_output_frequency % pllq as usize == 0);
 
         // Cache the frequency so it is not computed every time a get method is called
         self.frequency.set(desired_frequency_mhz);
@@ -349,7 +351,6 @@ impl<'a> Pll<'a> {
         self.pll48_calibrated.unwrap_or_panic()
     }
 }
-
 
 /// Tests for the PLL clock
 ///
@@ -418,7 +419,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy8, pllp);
         let mut plln = Pll::compute_plln(13, pllp);
         assert_eq!(52 * MULTIPLIER, plln);
-        let mut vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        let mut vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         let mut pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy3, pllq);
 
@@ -427,7 +428,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy8, pllp);
         plln = Pll::compute_plln(25, pllp);
         assert_eq!(100 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy5, pllq);
 
@@ -436,7 +437,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy8, pllp);
         plln = Pll::compute_plln(54, pllp);
         assert_eq!(216 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy9, pllq);
 
@@ -445,7 +446,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy6, pllp);
         plln = Pll::compute_plln(55, pllp);
         assert_eq!(165 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy7, pllq);
 
@@ -454,7 +455,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy6, pllp);
         plln = Pll::compute_plln(70, pllp);
         assert_eq!(210 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy9, pllq);
 
@@ -463,7 +464,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy6, pllp);
         plln = Pll::compute_plln(72, pllp);
         assert_eq!(216 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy9, pllq);
 
@@ -472,7 +473,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy4, pllp);
         plln = Pll::compute_plln(73, pllp);
         assert_eq!(146 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy7, pllq);
 
@@ -481,7 +482,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy4, pllp);
         plln = Pll::compute_plln(100, pllp);
         assert_eq!(200 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy9, pllq);
 
@@ -490,7 +491,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy4, pllp);
         plln = Pll::compute_plln(108, pllp);
         assert_eq!(216 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy9, pllq);
 
@@ -499,7 +500,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy2, pllp);
         plln = Pll::compute_plln(109, pllp);
         assert_eq!(109 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy5, pllq);
 
@@ -508,7 +509,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy2, pllp);
         plln = Pll::compute_plln(125, pllp);
         assert_eq!(125 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy6, pllq);
 
@@ -517,7 +518,7 @@ pub mod tests {
         assert_eq!(PLLP::DivideBy2, pllp);
         plln = Pll::compute_plln(180, pllp);
         assert_eq!(180 * MULTIPLIER, plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy8, pllq);
 
@@ -525,8 +526,8 @@ pub mod tests {
         pllp = Pll::compute_pllp(216);
         assert_eq!(PLLP::DivideBy2, pllp);
         plln = Pll::compute_plln(216, pllp);
-        assert_eq!(216 * MULTIPLIER , plln);
-        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize  * plln;
+        assert_eq!(216 * MULTIPLIER, plln);
+        vco_output_frequency_mhz = 16 / DEFAULT_PLLM_VALUE as usize * plln;
         pllq = Pll::compute_pllq(vco_output_frequency_mhz);
         assert_eq!(PLLQ::DivideBy9, pllq);
 

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs)]
-//! Main phase-locked loop (PLL) clock driver for the STM32F4xx family.
+//! Main phase-locked loop (PLL) clock driver for the STM32F4xx family. [^doc_ref]
 //!
 //! Many boards of the STM32F4xx family provide several PLL clocks. However, all of them have a
 //! main PLL clock. This driver is designed for the main PLL clock. It will be simply referred as
@@ -100,6 +100,8 @@
 //! }
 //! let pll48_frequency = optional_pll48_frequency.unwrap_or_panic();
 //! ```
+//!
+//! [^doc_ref]: See 6.2.3 in the documentation.
 
 
 use crate::rcc::*;

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -174,7 +174,7 @@ impl<'a> Pll<'a> {
     fn compute_pllq(vco_output_frequency_mhz: usize) -> PLLQ {
         for pllq in 3..10 {
             if 48 * pllq >= vco_output_frequency_mhz {
-                return PLLQ::from(pllq);
+                return PLLQ::try_from(pllq).unwrap();
             }
         }
         unreachable!("The previous for loop should always return");
@@ -269,7 +269,7 @@ impl<'a> Pll<'a> {
         // + PLL clock running
         // + invalid frequency
         if self.rcc.is_enabled_pll_clock() {
-            return Result::from(ErrorCode::FAIL);
+            return Err(ErrorCode::FAIL);
         } else if desired_frequency_mhz < 13 || desired_frequency_mhz > 216 {
             return Err(ErrorCode::INVAL);
         }

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -75,19 +75,19 @@ pub struct Pll<'a> {
 }
 
 impl<'a> Pll<'a> {
-    /// Create a new instance of the PLL clock.
-    ///
-    /// The instance of the PLL clock is configured to run at 96MHz and with minimal PLL jitter
-    /// effects.
-    ///
-    /// # Params
-    ///
-    /// + rcc: an instance of [crate::rcc]
-    ///
-    /// # Returns
-    ///
-    /// An instance of the PLL clock.
-    pub fn new(rcc: &'a Rcc) -> Self {
+    // Create a new instance of the PLL clock.
+    //
+    // The instance of the PLL clock is configured to run at 96MHz and with minimal PLL jitter
+    // effects.
+    //
+    // # Params
+    //
+    // + rcc: an instance of [crate::rcc]
+    //
+    // # Returns
+    //
+    // An instance of the PLL clock.
+    pub(crate) fn new(rcc: &'a Rcc) -> Self {
         const PLLP: usize = match DEFAULT_PLLP_VALUE {
             PLLP::DivideBy2 => 2,
             PLLP::DivideBy4 => 4,

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -201,11 +201,10 @@ impl<'a> Pll<'a> {
 
     /// Start the PLL clock.
     ///
-    /// # Returns
+    /// # Errors
     ///
     /// + [Err]\([ErrorCode::BUSY]\): if enabling the PLL clock took too long. Recall this method to
     /// ensure the PLL clock is running.
-    /// + [Ok]\(()\): PLL clock successfully enabled and running.
     pub fn enable(&self) -> Result<(), ErrorCode> {
         // Enable the PLL clock
         self.rcc.enable_pll_clock();
@@ -224,12 +223,11 @@ impl<'a> Pll<'a> {
 
     /// Stop the PLL clock.
     ///
-    /// # Returns
+    /// # Errors
     ///
     /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is configured as the system clock.
     /// + [Err]\([ErrorCode::BUSY]\): disabling the PLL clock took to long. Retry to ensure it is
     /// not running.
-    /// + [Ok]\(()\): PLL clock disabled and off.
     pub fn disable(&self) -> Result<(), ErrorCode> {
         // Can't disable the PLL clock when it is used as the system clock
         if self.rcc.get_sys_clock_source() == SysClockSource::PLL {
@@ -280,12 +278,11 @@ impl<'a> Pll<'a> {
     /// + desired_frequency_mhz: the desired frequency in MHz. Supported values: 24-216MHz for
     /// STM32F401 and 13-216MHz for all the other chips
     ///
-    /// # Returns
+    /// # Errors
     ///
     /// + [Err]\([ErrorCode::INVAL]\): if the desired frequency can't be achieved
     /// + [Err]\([ErrorCode::FAIL]\): if the PLL clock is already enabled. It must be disabled before
     /// configuring it.
-    /// + [Ok]\(()\): the PLL clock has been successfully configured
     pub fn set_frequency(&self, desired_frequency_mhz: usize) -> Result<(), ErrorCode> {
         // Check for errors:
         // + PLL clock running

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -1,0 +1,227 @@
+use crate::rcc::Rcc;
+use crate::rcc::PLLP;
+
+use kernel::debug;
+use kernel::ErrorCode;
+
+#[derive(Debug, PartialEq)]
+struct PllConfig {
+    p: PLLP,
+    n: usize,
+}
+
+impl Default for PllConfig {
+    fn default() -> Self {
+        Self {
+            p: PLLP::DivideBy2,
+            n: 100,
+        }
+    }
+}
+
+impl PllConfig {
+    fn get_p(&self) -> PLLP {
+        self.p
+    }
+
+    fn set_p(&mut self, p: PLLP) {
+        self.p = p;
+    }
+
+    fn get_n(&self) -> usize {
+        self.n
+    }
+
+    fn set_n(&mut self, n: usize) -> Result<(), ErrorCode> {
+        if n < 50 || n >= 432 {
+            return Result::from(ErrorCode::INVAL);
+        }
+        self.n = n;
+
+        Ok(())
+    }
+}
+
+/// Main PLL clock.
+
+// At the moment, only HSI is supported as the source clock.
+pub struct Pll<'a> {
+    rcc: &'a Rcc,
+}
+
+impl<'a> Pll<'a> {
+    pub fn new(rcc: &'a Rcc) -> Self {
+        Self {
+            rcc,
+        }
+    }
+
+    // **NOTE**: It assumes a value of 8 for PLLM
+    // **TODO**: Change this function so it can adapt to changes of the PLLM
+    fn get_pll_config_for_frequency_using_hsi(desired_frequency_mhz: usize) -> Option<PllConfig> {
+        if desired_frequency_mhz < 13 || desired_frequency_mhz > 216 {
+            return None;
+        }
+        let mut pll_config = PllConfig::default();
+        // As the documentation says, selecting a frequency of 2MHz for the VCO input frequency
+        // limits the PLL jitter. Since the HSI frequency is 16MHz, M must be configured
+        // accordingly.
+        pll_config.set_p(
+            if desired_frequency_mhz < 55 {
+                PLLP::DivideBy8
+            } else if desired_frequency_mhz < 73 {
+                PLLP::DivideBy6
+            } else if desired_frequency_mhz < 109 {
+                PLLP::DivideBy4
+            } else {
+                PLLP::DivideBy2
+            }
+        );
+        if let Err(_) = pll_config.set_n(match pll_config.get_p() {
+            PLLP::DivideBy8 => desired_frequency_mhz * 4,
+            PLLP::DivideBy6 => desired_frequency_mhz * 3,
+            PLLP::DivideBy4 => desired_frequency_mhz * 2,
+            _ => desired_frequency_mhz * 1,
+        }) {
+            return None;
+        }
+
+        Some(pll_config)
+    }
+
+    /// Start PLL clock. It supports only HSI as source at the moment.
+    /// Returns:
+    /// + Err(ErrorCode::INVAL) if the desired frequency can't be achieved
+    /// + Err(ErrorCode::FAIL) if any PLL clock is already enabled. They must be disabled before
+    /// configuring them again.
+    /// + Err(ErrorCode::BUSY) starting the PLL clock took too long. Retry.
+    /// + Ok(()) everything went OK
+    pub fn start(&self, desired_frequency_mhz: usize) -> Result<(), ErrorCode> {
+        // Check whether the PLL clock is running or not
+        if self.rcc.is_enabled_pll_clock() {
+            return Result::from(ErrorCode::FAIL);
+        }
+        // Config the PLL
+        let pll_config = Self::get_pll_config_for_frequency_using_hsi(desired_frequency_mhz);
+        if let None = pll_config {
+            return Result::from(ErrorCode::INVAL);
+        }
+        let pll_config = pll_config.unwrap();
+        self.rcc.set_pll_clock_n_multiplier(pll_config.get_n());
+        self.rcc.set_pll_clock_p_divider(pll_config.get_p());
+
+        // Enable PLL clock
+        self.rcc.enable_pll_clock()
+    }
+
+    /// Stop PLL clock.
+    /// Returns:
+    /// + Err(ErrorCode::FAIL) if the PLL clock is configured as the system clock.
+    /// + Err(ErrorCode::BUSY) stoping the PLL clock took to long. Retry.
+    /// + Ok(()) everything went alright
+    pub fn stop(&self) -> Result<(), ErrorCode> {
+        self.rcc.disable_pll_clock()
+    }
+}
+
+pub mod unit_tests {
+    use super::*;
+
+    fn test_get_pll_config_for_frequency_using_hsi() {
+        debug!("Testing PLL config...");
+
+        // Desired frequency can't be achieved
+        assert_eq!(None, Pll::get_pll_config_for_frequency_using_hsi(12));
+        assert_eq!(None, Pll::get_pll_config_for_frequency_using_hsi(217));
+
+        // Reachable frequencies
+        // 13MHz --> minimum value
+        let pll_config = Pll::get_pll_config_for_frequency_using_hsi(13).unwrap();
+        assert_eq!(52, pll_config.get_n());
+        assert_eq!(PLLP::DivideBy8, pll_config.get_p());
+
+        // 25MHz --> minimum required value for Ethernet devices
+        let pll_config = Pll::get_pll_config_for_frequency_using_hsi(25).unwrap();
+        assert_eq!(100, pll_config.get_n());
+        assert_eq!(PLLP::DivideBy8, pll_config.get_p());
+
+        // 55MHz --> PLLP becomes DivideBy6
+        let pll_config = Pll::get_pll_config_for_frequency_using_hsi(55).unwrap();
+        assert_eq!(165, pll_config.get_n());
+        assert_eq!(PLLP::DivideBy6, pll_config.get_p());
+
+        // 70MHz --> Another value for PLLP::DivideBy6
+        let pll_config = Pll::get_pll_config_for_frequency_using_hsi(70).unwrap();
+        assert_eq!(210, pll_config.get_n());
+        assert_eq!(PLLP::DivideBy6, pll_config.get_p());
+
+        // 73MHz --> PLLP becomes DivideBy4
+        let pll_config = Pll::get_pll_config_for_frequency_using_hsi(73).unwrap();
+        assert_eq!(146, pll_config.get_n());
+        assert_eq!(PLLP::DivideBy4, pll_config.get_p());
+
+        // 100MHz --> Another value for PLLP::DivideBy4
+        let pll_config = Pll::get_pll_config_for_frequency_using_hsi(100).unwrap();
+        assert_eq!(200, pll_config.get_n());
+        assert_eq!(PLLP::DivideBy4, pll_config.get_p());
+
+        // 109MHz --> PLLP becomes DivideBy2
+        let pll_config = Pll::get_pll_config_for_frequency_using_hsi(109).unwrap();
+        assert_eq!(109, pll_config.get_n());
+        assert_eq!(PLLP::DivideBy2, pll_config.get_p());
+
+        // 125MHz --> Another value for PLLP::DivideBy2
+        let pll_config = Pll::get_pll_config_for_frequency_using_hsi(125).unwrap();
+        assert_eq!(125, pll_config.get_n());
+        assert_eq!(PLLP::DivideBy2, pll_config.get_p());
+
+        // 180MHz --> Max frequency for the CPU
+        let pll_config = Pll::get_pll_config_for_frequency_using_hsi(180).unwrap();
+        assert_eq!(180, pll_config.get_n());
+        assert_eq!(PLLP::DivideBy2, pll_config.get_p());
+
+        // 216MHz --> Max frequency for the CPU due to the VCO output frequency limit
+        let pll_config = Pll::get_pll_config_for_frequency_using_hsi(216).unwrap();
+        assert_eq!(216, pll_config.get_n());
+        assert_eq!(PLLP::DivideBy2, pll_config.get_p());
+
+        debug!("Finished testing PLL config.");
+    }
+
+    fn test_pll_start_stop<'a>(pll: &'a Pll<'a>) {
+        debug!("Testing start/stop PLL...");
+        // If the pll is already stop, nothing should happen
+        assert_eq!(Ok(()), pll.stop());
+
+        // Attempting to start PLL with either too high or too low frequency
+        assert_eq!(Err(ErrorCode::INVAL), pll.start(12));
+        assert_eq!(Err(ErrorCode::INVAL), pll.start(217));
+
+        // Start the PLL with 25MHz
+        assert_eq!(Ok(()), pll.start(25));
+
+        // Impossible to start the PLL if it is already started
+        assert_eq!(Err(ErrorCode::FAIL), pll.start(50));
+
+        // Stop PLL
+        assert_eq!(Ok(()), pll.stop());
+
+        // Now, it can be configured to run at 50MHz
+        assert_eq!(Ok(()), pll.start(50));
+        debug!("Finished testing start/stop PLL.");
+    }
+
+    pub fn run<'a>(pll: &'a Pll<'a>) {
+        debug!("");
+        debug!("===============================================");
+        debug!("Testing PLL...");
+        debug!("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        test_get_pll_config_for_frequency_using_hsi();
+        debug!("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        test_pll_start_stop(pll);
+        debug!("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        debug!("Finished testing PLL. Everything is alright!");
+        debug!("===============================================");
+        debug!("");
+    }
+}

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -47,13 +47,13 @@
 //! if let None = optional_pll_frequency {
 //!     /* Clock stopped */
 //! }
-//! let pll_frequency = optional_pll_frequency.unwrap_or_panic();
+//! let pll_frequency = optional_pll_frequency.unwrap();
 //! /* Computations based on the PLL frequency */
 //! ```
 //!
 //! ## Stop the clock
 //!
-//! ```
+//! ```rust,ignore
 //! pll.disable();
 //! ```
 //!
@@ -85,7 +85,7 @@
 //! ```
 //!
 //! ## Check if the PLL48CLK output is calibrated.
-//! ```
+//! ```rust,ignore
 //! if !pll.is_pll48_calibrated() {
 //!     /* Handle the case when it is not calibrated */
 //! }
@@ -93,20 +93,20 @@
 //!
 //! ## Get the frequency of the PLL48CLK output
 //!
-//! ```
+//! ```rust,ignore
 //! let optional_pll48_frequency = pll.get_frequency();
 //! if let None = optional_pll48_frequency {
 //!     /* Clock stopped */
 //! }
-//! let pll48_frequency = optional_pll48_frequency.unwrap_or_panic();
+//! let pll48_frequency = optional_pll48_frequency.unwrap();
 //! ```
 //!
 //! [^doc_ref]: See 6.2.3 in the documentation.
 
-use crate::rcc::{DEFAULT_PLLM_VALUE, DEFAULT_PLLN_VALUE, DEFAULT_PLLP_VALUE, DEFAULT_PLLQ_VALUE};
-use crate::rcc::{PLLM, PLLP, PLLQ};
 use crate::rcc::Rcc;
 use crate::rcc::SysClockSource;
+use crate::rcc::{DEFAULT_PLLM_VALUE, DEFAULT_PLLN_VALUE, DEFAULT_PLLP_VALUE, DEFAULT_PLLQ_VALUE};
+use crate::rcc::{PLLM, PLLP, PLLQ};
 
 use kernel::debug;
 use kernel::utilities::cells::OptionalCell;

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -232,7 +232,7 @@ impl<'a> Pll<'a> {
     /// + [Ok]\(()\): PLL clock disabled and off.
     pub fn disable(&self) -> Result<(), ErrorCode> {
         // Can't disable the PLL clock when it is used as the system clock
-        if self.rcc.get_sys_clock_source() == SysClockSource::PLLCLK {
+        if self.rcc.get_sys_clock_source() == SysClockSource::PLL {
             return Err(ErrorCode::FAIL);
         }
 

--- a/chips/stm32f4xx/src/pll.rs
+++ b/chips/stm32f4xx/src/pll.rs
@@ -196,7 +196,8 @@ impl<'a> Pll<'a> {
         self.rcc.enable_pll_clock();
 
         // Wait until the PLL clock is locked.
-        for _ in 0..100 {
+        // 125 was obtained by running tests in release mode
+        for _ in 0..125 {
             if self.rcc.is_locked_pll_clock() {
                 return Ok(());
             }
@@ -224,7 +225,8 @@ impl<'a> Pll<'a> {
         self.rcc.disable_pll_clock();
 
         // Wait to unlock the PLL clock
-        for _ in 0..100 {
+        // 10 was obtained by testing in release mode
+        for _ in 0..10 {
             if self.rcc.is_locked_pll_clock() == false {
                 return Ok(());
             }

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -766,11 +766,11 @@ impl Rcc {
     }
 
     pub(crate) fn is_enabled_pll_clock(&self) -> bool {
-        self.registers.cr.read(CR::PLLON) == 1
+        self.registers.cr.is_set(CR::PLLON)
     }
 
     pub(crate) fn is_locked_pll_clock(&self) -> bool {
-        self.registers.cr.read(CR::PLLRDY) == 1
+        self.registers.cr.is_set(CR::PLLRDY)
     }
 
     // This method must be called only when all PLL clocks are disabled

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -769,9 +769,9 @@ impl Rcc {
         match self.registers.cfgr.read(CFGR::SWS) {
             0b00 => SysClockSource::HSI,
             //0b01 => SysClockSource::HSE, Uncomment this when HSE support is added
-            _ => SysClockSource::PLLCLK,
+            _ => SysClockSource::PLL,
             // Uncomment this when PPLLR support is added. Also change the above match arm to
-            // 0b10 => SysClockSource::PLLCLK,
+            // 0b10 => SysClockSource::PLL,
             //_ => SysClockSource::PPLLR,
         }
     }
@@ -1178,7 +1178,7 @@ pub(crate) enum PLLQ {
 pub enum SysClockSource {
     HSI = 0b00,
     //HSE = 0b01, Uncomment this when support for HSE is added
-    PLLCLK = 0b10,
+    PLL = 0b10,
     // NOTE: not all STM32F4xx boards support this source.
     //PPLLR = 0b11, Uncomment this when support for PPLLR is added
 }

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -706,8 +706,8 @@ const RCC_BASE: StaticRef<RccRegisters> =
 // Default values when the hardware is reset. Uncomment if you need them.
 //pub(crate) const RESET_PLLM_VALUE: usize = PLLM::DivideBy16; // M = 16
 pub(crate) const RESET_PLLN_VALUE: usize = 0b011_000_000; // N = 192
-                                                          //pub(crate) const RESET_PLLP_VALUE: PLLP = PLLP::DivideBy2; // P = 2
-                                                          //pub(crate) const RESET_PLLQ_VALUE: PLLQ = PLLQ::DivideBy4; // Q = 4
+//pub(crate) const RESET_PLLP_VALUE: PLLP = PLLP::DivideBy2; // P = 2
+//pub(crate) const RESET_PLLQ_VALUE: PLLQ = PLLQ::DivideBy4; // Q = 4
 
 // Default PLL configuration. See Rcc::init_pll_clock() for more details.
 //

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -710,6 +710,11 @@ pub(crate) const RESET_PLLN_VALUE: usize = 0b011_000_000; // N = 192
 
 // The default PLL configuration. See Rss::init_pll_clock() for more details.
 pub(crate) const DEFAULT_PLLM_VALUE: PLLM = PLLM::DivideBy8;
+// **HELP:** Does tock support static asserts? Changing DEFAULT_PLLN_VALUE might change the default
+// PLL frequency of 96MHz. TRNG relies on this value to get its 48MHz frequency (see
+// Rcc::configure_rng_clock()). Either the default frequency value of the PLL is statically
+// asserted to prevent subtle bugs or change the TRNG peripheral implementation to take into
+// account the possible variation of the main Pll clock.
 pub(crate) const DEFAULT_PLLN_VALUE: usize = RESET_PLLN_VALUE;
 pub(crate) const DEFAULT_PLLP_VALUE: PLLP = match DEFAULT_PLLM_VALUE {
     PLLM::DivideBy16 => PLLP::DivideBy2,
@@ -1123,6 +1128,8 @@ pub(crate) enum PLLP {
     DivideBy8 = 0b11,
 }
 
+// Theoretically, the PLLM value can range from 2 to 63. However, the current implementation was
+// designed to support 1MHz frequency precision. In a future update, PLLM will become a usize.
 #[allow(dead_code)]
 pub(crate) enum PLLM {
     DivideBy8,

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -754,10 +754,7 @@ impl Rcc {
     // dividing this frequency by 2.
     fn init_pll_clock(&self) {
         self.set_pll_clocks_source(PllSource::HSI);
-        self.set_pll_clocks_m_divider(match DEFAULT_PLLM_VALUE {
-            PLLM::DivideBy16 => 16,
-            PLLM::DivideBy8 => 8,
-        });
+        self.set_pll_clocks_m_divider(DEFAULT_PLLM_VALUE);
         self.set_pll_clock_n_multiplier(DEFAULT_PLLN_VALUE);
         self.set_pll_clock_p_divider(DEFAULT_PLLP_VALUE);
     }
@@ -784,7 +781,7 @@ impl Rcc {
     }
 
     // This method must be called only when all PLL clocks are disabled
-    pub(crate) fn set_pll_clocks_m_divider(&self, m: usize) {
+    pub(crate) fn set_pll_clocks_m_divider(&self, m: PLLM) {
         self.registers.pllcfgr.modify(PLLCFGR::PLLM.val(m as u32));
     }
 
@@ -1132,8 +1129,8 @@ pub(crate) enum PLLP {
 // designed to support 1MHz frequency precision. In a future update, PLLM will become a usize.
 #[allow(dead_code)]
 pub(crate) enum PLLM {
-    DivideBy8,
-    DivideBy16,
+    DivideBy8 = 8,
+    DivideBy16 = 16,
 }
 
 /// Clock sources for the CPU

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -703,12 +703,12 @@ register_bitfields![u32,
 const RCC_BASE: StaticRef<RccRegisters> =
     unsafe { StaticRef::new(0x40023800 as *const RccRegisters) };
 
-// Default values when the hardware is reset. Uncomment if you need themn.
+// Default values when the hardware is reset. Uncomment if you need them.
 //pub(crate) const RESET_PLLM_VALUE: usize = PLLM::DivideBy16; // M = 16
 pub(crate) const RESET_PLLN_VALUE: usize = 0b011_000_000; // N = 192
 //pub(crate) const RESET_PLLP_VALUE: PLLP = PLLP::DivideBy2; // P = 2
 
-// The default PLL configuration. See Rss::init_pll_clock() for more details.
+// The default PLL configuration. See Rcc::init_pll_clock() for more details.
 pub(crate) const DEFAULT_PLLM_VALUE: PLLM = PLLM::DivideBy8;
 // **HELP:** Does tock support static asserts? Changing DEFAULT_PLLN_VALUE might change the default
 // PLL frequency of 96MHz. TRNG relies on this value to get its 48MHz frequency (see

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -739,11 +739,7 @@ impl Rcc {
     }
 
     pub(crate) fn get_sys_clock_source(&self) -> SysClockSource {
-        match self.registers.cfgr.read(CFGR::SWS) {
-            0b00 => SysClockSource::HSI,
-            0b01 => SysClockSource::HSE,
-            _ => SysClockSource::PLLCLK,
-        }
+        SysClockSource::try_from(self.registers.cfgr.read(CFGR::SWS)).unwrap()
     }
 
     // Some clocks may need to be initialized before use
@@ -1162,17 +1158,20 @@ pub(crate) enum PLLQ {
     DivideBy9,
 }
 
-impl From<usize> for PLLQ {
-    fn from(value: usize) -> Self {
+impl TryFrom<usize> for PLLQ {
+    type Error = &'static str;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
         match value {
-            2 => PLLQ::DivideBy2,
-            3 => PLLQ::DivideBy3,
-            4 => PLLQ::DivideBy4,
-            5 => PLLQ::DivideBy5,
-            6 => PLLQ::DivideBy6,
-            7 => PLLQ::DivideBy7,
-            8 => PLLQ::DivideBy8,
-            _ => PLLQ::DivideBy9,
+            2 => Ok(PLLQ::DivideBy2),
+            3 => Ok(PLLQ::DivideBy3),
+            4 => Ok(PLLQ::DivideBy4),
+            5 => Ok(PLLQ::DivideBy5),
+            6 => Ok(PLLQ::DivideBy6),
+            7 => Ok(PLLQ::DivideBy7),
+            8 => Ok(PLLQ::DivideBy8),
+            9 => Ok(PLLQ::DivideBy9),
+            _ => Err("Invalid value for PLLQ::try_from"),
         }
     }
 }
@@ -1188,12 +1187,15 @@ pub enum SysClockSource {
     //PPLLR,
 }
 
-impl From<u32> for SysClockSource {
-    fn from(value: u32) -> Self {
+impl TryFrom<u32> for SysClockSource {
+    type Error = &'static str;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
-            0b00 => SysClockSource::HSI,
-            0b01 => SysClockSource::HSE,
-            _ => SysClockSource::PLLCLK,
+            0b00 => Ok(SysClockSource::HSI),
+            0b01 => Ok(SysClockSource::HSE),
+            0b10 => Ok(SysClockSource::PLLCLK),
+            _ => Err("Invalid value for SysClockSource::try_from"),
         }
     }
 }

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -705,9 +705,9 @@ const RCC_BASE: StaticRef<RccRegisters> =
 
 // Default values when the hardware is reset. Uncomment if you need them.
 //pub(crate) const RESET_PLLM_VALUE: usize = PLLM::DivideBy16; // M = 16
-pub(crate) const RESET_PLLN_VALUE: usize = 0b011_000_000; // N = 192
 //pub(crate) const RESET_PLLP_VALUE: PLLP = PLLP::DivideBy2; // P = 2
 //pub(crate) const RESET_PLLQ_VALUE: PLLQ = PLLQ::DivideBy4; // Q = 4
+pub(crate) const RESET_PLLN_VALUE: usize = 0b011_000_000; // N = 192
 
 // Default PLL configuration. See Rcc::init_pll_clock() for more details.
 //

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -716,12 +716,12 @@ pub(crate) const RESET_PLLN_VALUE: usize = 0b011_000_000; // N = 192
 pub(crate) const DEFAULT_PLLM_VALUE: PLLM = PLLM::DivideBy8;
 // DON'T CHANGE THIS VALUE
 pub(crate) const DEFAULT_PLLN_VALUE: usize = RESET_PLLN_VALUE;
-// Dynamically getting the default PLLP value based on the PLLM value
+// Dynamically computing the default PLLP value based on the PLLM value
 pub(crate) const DEFAULT_PLLP_VALUE: PLLP = match DEFAULT_PLLM_VALUE {
     PLLM::DivideBy16 => PLLP::DivideBy2,
     PLLM::DivideBy8 => PLLP::DivideBy4,
 };
-// Dynamically getting the default PLLP value based on the PLLM value
+// Dynamically computing the default PLLQ value based on the PLLM value
 pub(crate) const DEFAULT_PLLQ_VALUE: PLLQ = match DEFAULT_PLLM_VALUE {
     PLLM::DivideBy16 => PLLQ::DivideBy4,
     PLLM::DivideBy8 => PLLQ::DivideBy8,
@@ -1123,7 +1123,7 @@ impl Rcc {
     }
 }
 
-// **NOTE:** HSE is not yet supported as source clock.
+// NOTE: HSE is not yet supported as source clock.
 pub(crate) enum PllSource {
     HSI = 0b0,
     //HSE = 0b1,
@@ -1182,8 +1182,7 @@ pub enum SysClockSource {
     HSI = 0b00,
     HSE = 0b01,
     PLLCLK = 0b10,
-    // **NOTE:** is there any board that uses this as source for the system clock? Furthermore, not all chips
-    // for the STM32F4xx family support this option.
+    // NOTE: not all STM32F4xx boards support this source.
     //PPLLR,
 }
 

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -707,6 +707,7 @@ const RCC_BASE: StaticRef<RccRegisters> =
 //pub(crate) const RESET_PLLM_VALUE: usize = PLLM::DivideBy16; // M = 16
 pub(crate) const RESET_PLLN_VALUE: usize = 0b011_000_000; // N = 192
 //pub(crate) const RESET_PLLP_VALUE: PLLP = PLLP::DivideBy2; // P = 2
+//pub(crate) const RESET_PLLQ_VALUE: PLLQ = PLLQ::DivideBy4; // Q = 4
 
 // The default PLL configuration. See Rcc::init_pll_clock() for more details.
 pub(crate) const DEFAULT_PLLM_VALUE: PLLM = PLLM::DivideBy8;
@@ -761,6 +762,7 @@ impl Rcc {
         self.set_pll_clocks_m_divider(DEFAULT_PLLM_VALUE);
         self.set_pll_clock_n_multiplier(DEFAULT_PLLN_VALUE);
         self.set_pll_clock_p_divider(DEFAULT_PLLP_VALUE);
+        self.set_pll_clock_q_divider(DEFAULT_PLLQ_VALUE);
     }
 
     pub(crate) fn disable_pll_clock(&self) {

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -732,10 +732,12 @@ pub struct Rcc {
 }
 
 impl Rcc {
-    pub const fn new() -> Rcc {
-        Rcc {
+    pub fn new() -> Self {
+        let rcc = Self {
             registers: RCC_BASE,
-        }
+        };
+        rcc.init();
+        rcc
     }
 
     pub(crate) fn get_sys_clock_source(&self) -> SysClockSource {

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -704,14 +704,17 @@ const RCC_BASE: StaticRef<RccRegisters> =
     unsafe { StaticRef::new(0x40023800 as *const RccRegisters) };
 
 // Default values when the hardware is reset. Uncomment if you need themn.
-//pub(crate) const RESET_PLLM_VALUE: usize = 0b010_000; // M = 16
+//pub(crate) const RESET_PLLM_VALUE: usize = PLLM::DivideBy16; // M = 16
 pub(crate) const RESET_PLLN_VALUE: usize = 0b011_000_000; // N = 192
-//pub(crate) const RESET_PLLP_VALUE: PLLP = PLLP::DivideBy2;
+//pub(crate) const RESET_PLLP_VALUE: PLLP = PLLP::DivideBy2; // P = 2
 
 // The default PLL configuration. See Rss::init_pll_clock() for more details.
-pub(crate) const DEFAULT_PLLM_VALUE: usize = 8;
+pub(crate) const DEFAULT_PLLM_VALUE: PLLM = PLLM::DivideBy8;
 pub(crate) const DEFAULT_PLLN_VALUE: usize = RESET_PLLN_VALUE;
-pub(crate) const DEFAULT_PLLP_VALUE: PLLP = PLLP::DivideBy4;
+pub(crate) const DEFAULT_PLLP_VALUE: PLLP = match DEFAULT_PLLM_VALUE {
+    PLLM::DivideBy16 => PLLP::DivideBy2,
+    PLLM::DivideBy8 => PLLP::DivideBy4,
+};
 
 pub struct Rcc {
     registers: StaticRef<RccRegisters>,
@@ -746,7 +749,10 @@ impl Rcc {
     // dividing this frequency by 2.
     fn init_pll_clock(&self) {
         self.set_pll_clocks_source(PllSource::HSI);
-        self.set_pll_clocks_m_divider(DEFAULT_PLLM_VALUE);
+        self.set_pll_clocks_m_divider(match DEFAULT_PLLM_VALUE {
+            PLLM::DivideBy16 => 16,
+            PLLM::DivideBy8 => 8,
+        });
         self.set_pll_clock_n_multiplier(DEFAULT_PLLN_VALUE);
         self.set_pll_clock_p_divider(DEFAULT_PLLP_VALUE);
     }
@@ -773,7 +779,7 @@ impl Rcc {
     }
 
     // This method must be called only when all PLL clocks are disabled
-    fn set_pll_clocks_m_divider(&self, m: usize) {
+    pub(crate) fn set_pll_clocks_m_divider(&self, m: usize) {
         self.registers.pllcfgr.modify(PLLCFGR::PLLM.val(m as u32));
     }
 
@@ -1113,6 +1119,11 @@ pub enum PLLP {
     DivideBy4 = 0b01,
     DivideBy6 = 0b10,
     DivideBy8 = 0b11,
+}
+
+pub enum PLLM {
+    DivideBy8,
+    DivideBy16,
 }
 
 /// Clock sources for the CPU

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -770,7 +770,6 @@ impl Rcc {
         SysClockSource::try_from(self.registers.cfgr.read(CFGR::SWS)).unwrap()
     }
 
-
     /* Main PLL clock*/
 
     // The main PLL clock must not be configured as the sistem clock.

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -2,6 +2,7 @@ use kernel::platform::chip::ClockInterface;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
+use kernel::ErrorCode;
 
 /// Reset and clock control
 #[repr(C)]
@@ -100,41 +101,21 @@ register_bitfields![u32,
         /// Main PLL (PLL) division factor for USB OTG FS, SDIO and random num
         PLLQ OFFSET(24) NUMBITS(4) [],
         /// Main PLL(PLL) and audio PLL (PLLI2S) entry clock source
-        PLLSRC OFFSET(22) NUMBITS(1) [],
+        PLLSRC OFFSET(22) NUMBITS(1) [
+            HSI = 0,
+            HSE = 1,
+        ],
         /// Main PLL (PLL) division factor for main system clock
-        PLLP1 OFFSET(17) NUMBITS(1) [],
-        /// Main PLL (PLL) division factor for main system clock
-        PLLP0 OFFSET(16) NUMBITS(1) [],
+        PLLP OFFSET(16) NUMBITS(2) [
+            DivideBy2 = 0b00,
+            DivideBy4 = 0b01,
+            DivideBy6 = 0b10,
+            DivideBy8 = 0b11,
+        ],
         /// Main PLL (PLL) multiplication factor for VCO
-        PLLN8 OFFSET(14) NUMBITS(1) [],
-        /// Main PLL (PLL) multiplication factor for VCO
-        PLLN7 OFFSET(13) NUMBITS(1) [],
-        /// Main PLL (PLL) multiplication factor for VCO
-        PLLN6 OFFSET(12) NUMBITS(1) [],
-        /// Main PLL (PLL) multiplication factor for VCO
-        PLLN5 OFFSET(11) NUMBITS(1) [],
-        /// Main PLL (PLL) multiplication factor for VCO
-        PLLN4 OFFSET(10) NUMBITS(1) [],
-        /// Main PLL (PLL) multiplication factor for VCO
-        PLLN3 OFFSET(9) NUMBITS(1) [],
-        /// Main PLL (PLL) multiplication factor for VCO
-        PLLN2 OFFSET(8) NUMBITS(1) [],
-        /// Main PLL (PLL) multiplication factor for VCO
-        PLLN1 OFFSET(7) NUMBITS(1) [],
-        /// Main PLL (PLL) multiplication factor for VCO
-        PLLN0 OFFSET(6) NUMBITS(1) [],
+        PLLN OFFSET(6) NUMBITS(9) [],
         /// Division factor for the main PLL (PLL) and audio PLL (PLLI2S) inpu
-        PLLM5 OFFSET(5) NUMBITS(1) [],
-        /// Division factor for the main PLL (PLL) and audio PLL (PLLI2S) inpu
-        PLLM4 OFFSET(4) NUMBITS(1) [],
-        /// Division factor for the main PLL (PLL) and audio PLL (PLLI2S) inpu
-        PLLM3 OFFSET(3) NUMBITS(1) [],
-        /// Division factor for the main PLL (PLL) and audio PLL (PLLI2S) inpu
-        PLLM2 OFFSET(2) NUMBITS(1) [],
-        /// Division factor for the main PLL (PLL) and audio PLL (PLLI2S) inpu
-        PLLM1 OFFSET(1) NUMBITS(1) [],
-        /// Division factor for the main PLL (PLL) and audio PLL (PLLI2S) inpu
-        PLLM0 OFFSET(0) NUMBITS(1) []
+        PLLM OFFSET(0) NUMBITS(6) []
     ],
     CFGR [
         /// Microcontroller clock output 2
@@ -156,13 +137,13 @@ register_bitfields![u32,
         /// AHB prescaler
         HPRE OFFSET(4) NUMBITS(4) [],
         /// System clock switch status
-        SWS1 OFFSET(3) NUMBITS(1) [],
-        /// System clock switch status
-        SWS0 OFFSET(2) NUMBITS(1) [],
+        SWS OFFSET(2) NUMBITS(2) [],
         /// System clock switch
-        SW1 OFFSET(1) NUMBITS(1) [],
-        /// System clock switch
-        SW0 OFFSET(0) NUMBITS(1) []
+        SW OFFSET(0) NUMBITS(2) [
+            HSI = 0b00,
+            HSE = 0b01,
+            PLL = 0b10,
+        ]
     ],
     CIR [
         /// Clock security system interrupt clear
@@ -734,6 +715,81 @@ impl Rcc {
         }
     }
 
+    fn wait_for(count: usize, f: impl Fn() -> bool) -> bool {
+        for _ in 0..count {
+            if f() {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Some clocks may need to be initialized before use
+    pub fn init(&self) {
+        self.init_pll_clocks();
+    }
+
+    fn init_pll_clocks(&self) {
+        // Setting HSI as source clock for the PLL clocks
+        self.set_pll_clocks_source(PllSource::HSI);
+        // As the documentation says, setting the input VCO frequency to 2MHz limits the effects of
+        // the PLL jitter: HSI_freq / PLLM --> 16MHz / 8 --> 2Mhz
+        self.set_pll_clocks_m_divider(8);
+    }
+
+    pub(crate) fn disable_pll_clock(&self) -> Result<(), ErrorCode> {
+        // If PLL is configured as the system clock, then it is impossible to disable it
+        if self.registers.cfgr.read(CFGR::SWS) == 0b10 {
+            return Result::from(ErrorCode::FAIL);
+        }
+        // Disable PLL
+        self.registers.cr.modify(CR::PLLON::CLEAR);
+        // Wait until PLL is unlocked by the CPU. Retry if it takes too long.
+        if let false = Self::wait_for(100, || {
+            self.registers.cr.read(CR::PLLRDY) == 0
+        }) {
+            return Result::from(ErrorCode::BUSY);
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn enable_pll_clock(&self) -> Result<(), ErrorCode> {
+        // Enable PLL
+        self.registers.cr.modify(CR::PLLON::SET);
+        // Wait until PLL is locked by the CPU. Retry if it takes too long.
+        if let false = Self::wait_for(100, || {
+            self.registers.cr.read(CR::PLLRDY) == 1
+        }) {
+            return Result::from(ErrorCode::BUSY);
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn is_enabled_pll_clock(&self) -> bool {
+        self.registers.cr.read(CR::PLLON) == 1
+    }
+
+    // This method must be called only when all PLL clocks are disabled
+    fn set_pll_clocks_source(&self, source: PllSource) {
+        self.registers.pllcfgr.modify(PLLCFGR::PLLSRC.val(source as u32));
+    }
+
+    // This method must be called only when all PLL clocks are disabled
+    fn set_pll_clocks_m_divider(&self, m: usize) {
+        self.registers.pllcfgr.modify(PLLCFGR::PLLM.val(m as u32));
+    }
+
+    pub(crate) fn set_pll_clock_n_multiplier(&self, n: usize) {
+        self.registers.pllcfgr.modify(PLLCFGR::PLLN.val(n as u32));
+    }
+
+    pub(crate) fn set_pll_clock_p_divider(&self, p: PLLP) {
+        self.registers.pllcfgr.modify(PLLCFGR::PLLP.val(p as u32));
+    }
+
     fn configure_rng_clock(&self) {
         self.registers.pllcfgr.modify(PLLCFGR::PLLQ.val(2));
         self.registers.cr.modify(CR::PLLON::SET);
@@ -1050,12 +1106,38 @@ impl Rcc {
     }
 }
 
-/// Clock sources for CPU
-pub enum CPUClock {
-    HSE,
-    HSI,
-    PLLCLK,
-    PPLLR,
+// **NOTE:** HSE is not yet supported as source clock.
+pub enum PllSource {
+    HSI = 0b0,
+    HSE = 0b1,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum PLLP {
+    DivideBy2 = 0b00,
+    DivideBy4 = 0b01,
+    DivideBy6 = 0b10,
+    DivideBy8 = 0b11,
+}
+
+/// Clock sources for the CPU
+pub enum SysClockSource {
+    HSI = 0b00,
+    HSE = 0b01,
+    PLLCLK = 0b10,
+    // **NOTE:** is there any board that uses this as source for the system clock? Furthermore, not all chips
+    // for the STM32F4xx family support this option.
+    //PPLLR,
+}
+
+impl From<u32> for SysClockSource {
+    fn from(value: u32) -> Self {
+        match value {
+            0b00 => SysClockSource::HSI,
+            0b01 => SysClockSource::HSE,
+            _ => SysClockSource::PLLCLK
+        }
+    }
 }
 
 pub struct PeripheralClock<'a> {

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -706,8 +706,8 @@ const RCC_BASE: StaticRef<RccRegisters> =
 // Default values when the hardware is reset. Uncomment if you need them.
 //pub(crate) const RESET_PLLM_VALUE: usize = PLLM::DivideBy16; // M = 16
 pub(crate) const RESET_PLLN_VALUE: usize = 0b011_000_000; // N = 192
-//pub(crate) const RESET_PLLP_VALUE: PLLP = PLLP::DivideBy2; // P = 2
-//pub(crate) const RESET_PLLQ_VALUE: PLLQ = PLLQ::DivideBy4; // Q = 4
+                                                          //pub(crate) const RESET_PLLP_VALUE: PLLP = PLLP::DivideBy2; // P = 2
+                                                          //pub(crate) const RESET_PLLQ_VALUE: PLLQ = PLLQ::DivideBy4; // Q = 4
 
 // Default PLL configuration. See Rcc::init_pll_clock() for more details.
 //
@@ -786,7 +786,9 @@ impl Rcc {
 
     // This method must be called only when all PLL clocks are disabled
     pub(crate) fn set_pll_clocks_source(&self, source: PllSource) {
-        self.registers.pllcfgr.modify(PLLCFGR::PLLSRC.val(source as u32));
+        self.registers
+            .pllcfgr
+            .modify(PLLCFGR::PLLSRC.val(source as u32));
     }
 
     // This method must be called only when all PLL clocks are disabled
@@ -1191,7 +1193,7 @@ impl From<u32> for SysClockSource {
         match value {
             0b00 => SysClockSource::HSI,
             0b01 => SysClockSource::HSE,
-            _ => SysClockSource::PLLCLK
+            _ => SysClockSource::PLLCLK,
         }
     }
 }

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -720,6 +720,10 @@ pub(crate) const DEFAULT_PLLP_VALUE: PLLP = match DEFAULT_PLLM_VALUE {
     PLLM::DivideBy16 => PLLP::DivideBy2,
     PLLM::DivideBy8 => PLLP::DivideBy4,
 };
+pub(crate) const DEFAULT_PLLQ_VALUE: PLLQ = match DEFAULT_PLLM_VALUE {
+    PLLM::DivideBy16 => PLLQ::DivideBy4,
+    PLLM::DivideBy8 => PLLQ::DivideBy8,
+};
 
 pub struct Rcc {
     registers: StaticRef<RccRegisters>,
@@ -793,6 +797,11 @@ impl Rcc {
     // This method must be called only if the main PLL clock is disabled
     pub(crate) fn set_pll_clock_p_divider(&self, p: PLLP) {
         self.registers.pllcfgr.modify(PLLCFGR::PLLP.val(p as u32));
+    }
+
+    // This method must be called only if the main PLL clock is disabled
+    pub(crate) fn set_pll_clock_q_divider(&self, q: PLLQ) {
+        self.registers.pllcfgr.modify(PLLCFGR::PLLQ.val(q as u32));
     }
 
     fn configure_rng_clock(&self) {
@@ -1131,6 +1140,33 @@ pub(crate) enum PLLP {
 pub(crate) enum PLLM {
     DivideBy8 = 8,
     DivideBy16 = 16,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub(crate) enum PLLQ {
+    DivideBy2 = 2,
+    DivideBy3,
+    DivideBy4,
+    DivideBy5,
+    DivideBy6,
+    DivideBy7,
+    DivideBy8,
+    DivideBy9,
+}
+
+impl From<usize> for PLLQ {
+    fn from(value: usize) -> Self {
+        match value {
+            2 => PLLQ::DivideBy2,
+            3 => PLLQ::DivideBy3,
+            4 => PLLQ::DivideBy4,
+            5 => PLLQ::DivideBy5,
+            6 => PLLQ::DivideBy6,
+            7 => PLLQ::DivideBy7,
+            8 => PLLQ::DivideBy8,
+            _ => PLLQ::DivideBy9,
+        }
+    }
 }
 
 /// Clock sources for the CPU

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -774,7 +774,7 @@ impl Rcc {
     }
 
     // This method must be called only when all PLL clocks are disabled
-    fn set_pll_clocks_source(&self, source: PllSource) {
+    pub(crate) fn set_pll_clocks_source(&self, source: PllSource) {
         self.registers.pllcfgr.modify(PLLCFGR::PLLSRC.val(source as u32));
     }
 
@@ -783,10 +783,12 @@ impl Rcc {
         self.registers.pllcfgr.modify(PLLCFGR::PLLM.val(m as u32));
     }
 
+    // This method must be called only if the main PLL clock is disabled
     pub(crate) fn set_pll_clock_n_multiplier(&self, n: usize) {
         self.registers.pllcfgr.modify(PLLCFGR::PLLN.val(n as u32));
     }
 
+    // This method must be called only if the main PLL clock is disabled
     pub(crate) fn set_pll_clock_p_divider(&self, p: PLLP) {
         self.registers.pllcfgr.modify(PLLCFGR::PLLP.val(p as u32));
     }
@@ -1108,20 +1110,21 @@ impl Rcc {
 }
 
 // **NOTE:** HSE is not yet supported as source clock.
-pub enum PllSource {
+pub(crate) enum PllSource {
     HSI = 0b0,
-    HSE = 0b1,
+    //HSE = 0b1,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub enum PLLP {
+pub(crate) enum PLLP {
     DivideBy2 = 0b00,
     DivideBy4 = 0b01,
     DivideBy6 = 0b10,
     DivideBy8 = 0b11,
 }
 
-pub enum PLLM {
+#[allow(dead_code)]
+pub(crate) enum PLLM {
     DivideBy8,
     DivideBy16,
 }

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -709,18 +709,19 @@ pub(crate) const RESET_PLLN_VALUE: usize = 0b011_000_000; // N = 192
 //pub(crate) const RESET_PLLP_VALUE: PLLP = PLLP::DivideBy2; // P = 2
 //pub(crate) const RESET_PLLQ_VALUE: PLLQ = PLLQ::DivideBy4; // Q = 4
 
-// The default PLL configuration. See Rcc::init_pll_clock() for more details.
+// Default PLL configuration. See Rcc::init_pll_clock() for more details.
+//
+// Choose PLLM::DivideBy8 for reduced PLL jitter or PLLM::DivideBy16 for default hardware
+// configuration
 pub(crate) const DEFAULT_PLLM_VALUE: PLLM = PLLM::DivideBy8;
-// **HELP:** Does tock support static asserts? Changing DEFAULT_PLLN_VALUE might change the default
-// PLL frequency of 96MHz. TRNG relies on this value to get its 48MHz frequency (see
-// Rcc::configure_rng_clock()). Either the default frequency value of the PLL is statically
-// asserted to prevent subtle bugs or change the TRNG peripheral implementation to take into
-// account the possible variation of the main Pll clock.
+// DON'T CHANGE THIS VALUE
 pub(crate) const DEFAULT_PLLN_VALUE: usize = RESET_PLLN_VALUE;
+// Dynamically getting the default PLLP value based on the PLLM value
 pub(crate) const DEFAULT_PLLP_VALUE: PLLP = match DEFAULT_PLLM_VALUE {
     PLLM::DivideBy16 => PLLP::DivideBy2,
     PLLM::DivideBy8 => PLLP::DivideBy4,
 };
+// Dynamically getting the default PLLP value based on the PLLM value
 pub(crate) const DEFAULT_PLLQ_VALUE: PLLQ = match DEFAULT_PLLM_VALUE {
     PLLM::DivideBy16 => PLLQ::DivideBy4,
     PLLM::DivideBy8 => PLLQ::DivideBy8,
@@ -765,6 +766,7 @@ impl Rcc {
         self.set_pll_clock_q_divider(DEFAULT_PLLQ_VALUE);
     }
 
+    /* Main PLL clock*/
     pub(crate) fn disable_pll_clock(&self) {
         self.registers.cr.modify(CR::PLLON::CLEAR);
     }
@@ -777,6 +779,7 @@ impl Rcc {
         self.registers.cr.is_set(CR::PLLON)
     }
 
+    // The PLL clock is locked when its signal is stable
     pub(crate) fn is_locked_pll_clock(&self) -> bool {
         self.registers.cr.is_set(CR::PLLRDY)
     }
@@ -1145,6 +1148,7 @@ pub(crate) enum PLLM {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
+// Due to the restricted values for PLLM, PLLQ 10-15 values are meaningless.
 pub(crate) enum PLLQ {
     DivideBy2 = 2,
     DivideBy3,

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -703,6 +703,16 @@ register_bitfields![u32,
 const RCC_BASE: StaticRef<RccRegisters> =
     unsafe { StaticRef::new(0x40023800 as *const RccRegisters) };
 
+// Default values when the hardware is reset. Uncomment if you need themn.
+//pub(crate) const RESET_PLLM_VALUE: usize = 0b010_000; // M = 16
+pub(crate) const RESET_PLLN_VALUE: usize = 0b011_000_000; // N = 192
+//pub(crate) const RESET_PLLP_VALUE: PLLP = PLLP::DivideBy2;
+
+// The default PLL configuration. See Rss::init_pll_clock() for more details.
+pub(crate) const DEFAULT_PLLM_VALUE: usize = 8;
+pub(crate) const DEFAULT_PLLN_VALUE: usize = RESET_PLLN_VALUE;
+pub(crate) const DEFAULT_PLLP_VALUE: PLLP = PLLP::DivideBy4;
+
 pub struct Rcc {
     registers: StaticRef<RccRegisters>,
 }
@@ -724,15 +734,21 @@ impl Rcc {
 
     // Some clocks may need to be initialized before use
     pub fn init(&self) {
-        self.init_pll_clocks();
+        self.init_pll_clock();
     }
 
-    fn init_pll_clocks(&self) {
-        // Setting HSI as source clock for the PLL clocks
+    // Init the PLL clock. The default configuration:
+    // + sets HSI as the source clock
+    // + Provides a 2MHz VCO input frequency to reduce PLL jitter: freq_VCO_input = freq_source / PLLM
+    // + Provides a 384MHz VCO output frequency: freq_VCO_output = freq_VCO_input * PLLN
+    // + The PLL frequency is set to 96MHz: freq_PLL = freq_VCO_output / PLLP. This way, the 48MHz
+    // frequency required for USB OTG FS, SDIO and RNG peripherals can be easily obtained by
+    // dividing this frequency by 2.
+    fn init_pll_clock(&self) {
         self.set_pll_clocks_source(PllSource::HSI);
-        // As the documentation says, setting the input VCO frequency to 2MHz limits the effects of
-        // the PLL jitter: HSI_freq / PLLM --> 16MHz / 8 --> 2Mhz
-        self.set_pll_clocks_m_divider(8);
+        self.set_pll_clocks_m_divider(DEFAULT_PLLM_VALUE);
+        self.set_pll_clock_n_multiplier(DEFAULT_PLLN_VALUE);
+        self.set_pll_clock_p_divider(DEFAULT_PLLP_VALUE);
     }
 
     pub(crate) fn disable_pll_clock(&self) {

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -90,8 +90,8 @@ class CodeBlock(str):
 
 class Includes(CodeBlock):
     TEMPLATE = """
-use kernel::common::StaticRef;
-use kernel::common::registers::{{self, register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly}};
+use kernel::utilities::StaticRef;
+use kernel::utilities::registers::{{self, register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly}};
     """
 
 


### PR DESCRIPTION
## Pull request overview

This pull request adds support for the main PLL clock. Currently, the STM32F4xx
chips use the default HSI (high-speed internal) clock source. Its default
frequency is 16MHz. Most of the time, it may be enough, but some peripherals
require a higher frequency, such as Ethernet. This may be achieved by using the
main PLL clock as the system clock. Additionally, some peripherals clocks rely
on the PLL clock, such as USB OTG FS, the random number generator and SDIO.

# Implemented features

- [x] Default configuration of 96MHz with reduced PLL jitter
- [x] 1MHz frequency precision
- [x] Support for 13-216MHz frequency range
- [x] Support for PLL48CLK output

# Missing features

- [ ] Precision higher than 1MHz
- [ ] Source selection
- [ ] Precise control over the PLL48CLK frequency


## Implementation details

### Why a separate file?

A separate source file has been created for two reasons:

+ **rcc.rs** is already a pretty large file
+ the logic for the PLL clock is kept inside **pll.rs** and the register
operations inside **rcc.rs**

### PLL public interface

The public `Pll` interface resembles `kernel::platform::chip::ClockInterface`,
offering the same methods `enable`, `disable` and `is_enabled`, but returning
`Result` to allow the caller to handle errors. In addition, `get_frequency` and
`set_frequency` offer the possibility to query the frequency of the main PLL
clock and to set it. Furthermore, `get_frequency_pll48` and
`is_pll48_calibrated` allows to query the frequency of the PLL48CLK output and
to check whether it is calibrated or not, i.e. its frequency is exactly 48MHz.

### Frequency output

Due to the hardware structure, it is impossible to configure both outputs
independently. The implementation chose to focus on the main output and try to
configure in the best way the PLL48CLK output: set a 48MHz frequency if
possible, otherwise, the highest value less than 48MHz.

Also, the frequency value is cached to avoid reading the registers every time
it is needed. As a result, the PLL configuration register **must not** be
accessed outside the `Pll` struct. See TODO.

## Testing

This pull requests comes with both unit tests and integration tests. The
documentation explains how to run the tests. The tests were run on the
STM32F429ZI Nucleo-144.

## Documentation

- [x] Internal documentation
- [x] External documentation for public methods.

## Help wanted

+ Couldn't figure how to add static asserts based on the `register_fields!`
macro. They can help to detect pesky bugs when the default values for different
PLL configuration parameters are changed.
+ Run tests on other STM32F4xx based boards.

## TODO

+ Test with an oscilloscope 
+ Add higher precision.
+ Add source switching.
+ Rewrite TRNG peripheral driver to use the new PLL clock struct instead of
accessing the PLLCFGR register directly. See `configure_rng_clock()`.

## Formatting

- [x] Ran `make prepush`
