### PR TITLE
Virt/selection policy

### DIFF
--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -38,6 +38,7 @@
 use capsules_core::console;
 use capsules_core::console_ordered::ConsoleOrdered;
 
+use capsules_core::virtualizers::selection_policy::{InsertionFirstPolicy, SelectionPolicy};
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
@@ -53,45 +54,98 @@ use capsules_core::console::DEFAULT_BUF_SIZE;
 #[macro_export]
 macro_rules! uart_mux_component_static {
     // Common logic for both branches
-    ($rx_buffer_len: expr) => {{
+    ($rx_buffer_len: expr, $P: ty) => {{
         use capsules_core::virtualizers::virtual_uart::MuxUart;
         use kernel::static_buf;
-        let uart_mux = static_buf!(MuxUart<'static>);
+        let uart_mux = static_buf!(MuxUart<'static, $P>);
         let rx_buf = static_buf!([u8; $rx_buffer_len]);
         (uart_mux, rx_buf)
     }};
-    () => {
-        $crate::uart_mux_component_static!(capsules_core::virtualizers::virtual_uart::RX_BUF_LEN);
-    };
-    ($rx_buffer_len: literal) => {
-        $crate::uart_mux_component_static!($rx_buffer_len);
-    };
+    ($P: ty) => {{
+        $crate::uart_mux_component_static!(
+            capsules_core::virtualizers::virtual_uart::RX_BUF_LEN,
+            $P
+        )
+    }};
+    // By default, if no selection policy is provided we will use the `InsertionFirstPolicy`.
+    // This option has been chosen as the default to maintain backwards compatibility.
+    () => {{
+        use capsules_core::virtualizers::selection_policy::InsertionFirstPolicy;
+        $crate::uart_mux_component_static!(
+            capsules_core::virtualizers::virtual_uart::RX_BUF_LEN,
+            InsertionFirstPolicy
+        )
+    }};
+    ($rx_buffer_len: literal) => {{
+        use capsules_core::virtualizers::selection_policy::InsertionFirstPolicy;
+        $crate::uart_mux_component_static!($rx_buffer_len, InsertionFirstPolicy)
+    }};
 }
 
-pub struct UartMuxComponent<const RX_BUF_LEN: usize> {
+pub struct UartMuxComponent<
+    const RX_BUF_LEN: usize,
+    P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static = InsertionFirstPolicy,
+> {
     uart: &'static dyn uart::Uart<'static>,
     baud_rate: u32,
+    selection_policy: P,
 }
 
-impl<const RX_BUF_LEN: usize> UartMuxComponent<RX_BUF_LEN> {
+// Implemented for backward compatibility
+impl<const RX_BUF_LEN: usize> UartMuxComponent<RX_BUF_LEN, InsertionFirstPolicy> {
+    /// Create a new MuxComponent with the [`InsertionFirstPolicy`] selection policy.
     pub fn new(
         uart: &'static dyn uart::Uart<'static>,
         baud_rate: u32,
-    ) -> UartMuxComponent<RX_BUF_LEN> {
-        UartMuxComponent { uart, baud_rate }
+    ) -> UartMuxComponent<RX_BUF_LEN, InsertionFirstPolicy> {
+        UartMuxComponent {
+            uart,
+            baud_rate,
+            selection_policy: InsertionFirstPolicy,
+        }
     }
 }
 
-impl<const RX_BUF_LEN: usize> Component for UartMuxComponent<RX_BUF_LEN> {
+// Implemented to specify a custom selection policy
+impl<const RX_BUF_LEN: usize, P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static>
+    UartMuxComponent<RX_BUF_LEN, P>
+{
+    /// Create a new MuxComponent with a custom selection policy.
+    /// It determines which device will be selected next
+    /// from the list of devices in the virtualizer.
+    ///
+    /// For the default implementation, please refer to `new` function
+    /// which uses `InsertionFirstPolicy` selection polity.
+    pub fn new_with_policy(
+        uart: &'static dyn uart::Uart<'static>,
+        baud_rate: u32,
+        selection_policy: P,
+    ) -> UartMuxComponent<RX_BUF_LEN, P> {
+        UartMuxComponent {
+            uart,
+            baud_rate,
+            selection_policy,
+        }
+    }
+}
+
+impl<const RX_BUF_LEN: usize, P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static>
+    Component for UartMuxComponent<RX_BUF_LEN, P>
+{
     type StaticInput = (
-        &'static mut MaybeUninit<MuxUart<'static>>,
+        &'static mut MaybeUninit<MuxUart<'static, P>>,
         &'static mut MaybeUninit<[u8; RX_BUF_LEN]>,
     );
-    type Output = &'static MuxUart<'static>;
+    type Output = &'static MuxUart<'static, P>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let rx_buf = s.1.write([0; RX_BUF_LEN]);
-        let uart_mux = s.0.write(MuxUart::new(self.uart, rx_buf, self.baud_rate));
+        let uart_mux = s.0.write(MuxUart::new_with_policy(
+            self.uart,
+            rx_buf,
+            self.baud_rate,
+            self.selection_policy,
+        ));
         kernel::deferred_call::DeferredCallClient::register(uart_mux);
 
         uart_mux.initialize();
@@ -105,37 +159,54 @@ impl<const RX_BUF_LEN: usize> Component for UartMuxComponent<RX_BUF_LEN> {
 #[macro_export]
 macro_rules! console_component_static {
     // Common logic for both branches
-    ($rx_buffer_len: expr, $tx_buffer_len: expr) => {{
+    ($rx_buffer_len: expr, $tx_buffer_len: expr, $P: ty) => {{
         use capsules_core::console::{Console, DEFAULT_BUF_SIZE};
         use capsules_core::virtualizers::virtual_uart::UartDevice;
         use kernel::static_buf;
         let read_buf = static_buf!([u8; $rx_buffer_len]);
         let write_buf = static_buf!([u8; $tx_buffer_len]);
         // Create virtual device for console.
-        let console_uart = static_buf!(UartDevice);
+        let console_uart = static_buf!(UartDevice<$P>);
         let console = static_buf!(Console<'static>);
         (write_buf, read_buf, console_uart, console)
     }};
-    () => {
-        $crate::console_component_static!(DEFAULT_BUF_SIZE, DEFAULT_BUF_SIZE);
+    ($rx_buffer_len: literal, $tx_buffer_len: literal, $P: ty) => {
+        $crate::console_component_static!($rx_buffer_len, $tx_buffer_len, $P);
     };
-    ($rx_buffer_len: literal, $tx_buffer_len: literal) => {
-        $crate::console_component_static!($rx_buffer_len, $tx_buffer_len);
+    ($rx_buffer_len: literal, $tx_buffer_len: literal) => {{
+        use capsules_core::virtualizers::selection_policy::InsertionFirstPolicy;
+        $crate::console_component_static!($rx_buffer_len, $tx_buffer_len, InsertionFirstPolicy)
+    }};
+    ($P: ty) => {
+        $crate::console_component_static!(DEFAULT_BUF_SIZE, DEFAULT_BUF_SIZE, $P);
     };
+    () => {{
+        use capsules_core::virtualizers::selection_policy::InsertionFirstPolicy;
+        $crate::console_component_static!(DEFAULT_BUF_SIZE, DEFAULT_BUF_SIZE, InsertionFirstPolicy)
+    }};
 }
 
-pub struct ConsoleComponent<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> {
+pub struct ConsoleComponent<
+    const RX_BUF_LEN: usize,
+    const TX_BUF_LEN: usize,
+    P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
-    uart_mux: &'static MuxUart<'static>,
+    uart_mux: &'static MuxUart<'static, P>,
 }
 
-impl<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN> {
+impl<
+        const RX_BUF_LEN: usize,
+        const TX_BUF_LEN: usize,
+        P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static,
+    > ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN, P>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-        uart_mux: &'static MuxUart,
-    ) -> ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN> {
+        uart_mux: &'static MuxUart<P>,
+    ) -> ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN, P> {
         ConsoleComponent {
             board_kernel,
             driver_num,
@@ -144,13 +215,16 @@ impl<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> ConsoleComponent<RX_BUF_L
     }
 }
 
-impl<const RX_BUF_LEN: usize, const TX_BUF_LEN: usize> Component
-    for ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN>
+impl<
+        const RX_BUF_LEN: usize,
+        const TX_BUF_LEN: usize,
+        P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static,
+    > Component for ConsoleComponent<RX_BUF_LEN, TX_BUF_LEN, P>
 {
     type StaticInput = (
         &'static mut MaybeUninit<[u8; TX_BUF_LEN]>,
         &'static mut MaybeUninit<[u8; RX_BUF_LEN]>,
-        &'static mut MaybeUninit<UartDevice<'static>>,
+        &'static mut MaybeUninit<UartDevice<'static, P>>,
         &'static mut MaybeUninit<console::Console<'static>>,
     );
     type Output = &'static console::Console<'static>;
@@ -189,26 +263,33 @@ macro_rules! console_ordered_component_static {
     };};
 }
 
-pub struct ConsoleOrderedComponent<A: 'static + time::Alarm<'static>> {
+pub struct ConsoleOrderedComponent<
+    A: 'static + time::Alarm<'static>,
+    P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
-    uart_mux: &'static MuxUart<'static>,
+    uart_mux: &'static MuxUart<'static, P>,
     alarm_mux: &'static MuxAlarm<'static, A>,
     atomic_size: usize,
     retry_timer: u32,
     write_timer: u32,
 }
 
-impl<A: 'static + time::Alarm<'static>> ConsoleOrderedComponent<A> {
+impl<
+        A: 'static + time::Alarm<'static>,
+        P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static,
+    > ConsoleOrderedComponent<A, P>
+{
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-        uart_mux: &'static MuxUart<'static>,
+        uart_mux: &'static MuxUart<'static, P>,
         alarm_mux: &'static MuxAlarm<'static, A>,
         atomic_size: usize,
         retry_timer: u32,
         write_timer: u32,
-    ) -> ConsoleOrderedComponent<A> {
+    ) -> ConsoleOrderedComponent<A, P> {
         ConsoleOrderedComponent {
             board_kernel,
             driver_num,
@@ -221,11 +302,15 @@ impl<A: 'static + time::Alarm<'static>> ConsoleOrderedComponent<A> {
     }
 }
 
-impl<A: 'static + time::Alarm<'static>> Component for ConsoleOrderedComponent<A> {
+impl<
+        A: 'static + time::Alarm<'static>,
+        P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static,
+    > Component for ConsoleOrderedComponent<A, P>
+{
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
         &'static mut MaybeUninit<[u8; DEFAULT_BUF_SIZE]>,
-        &'static mut MaybeUninit<UartDevice<'static>>,
+        &'static mut MaybeUninit<UartDevice<'static, P>>,
         &'static mut MaybeUninit<ConsoleOrdered<'static, VirtualMuxAlarm<'static, A>>>,
     );
     type Output = &'static ConsoleOrdered<'static, VirtualMuxAlarm<'static, A>>;

--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -27,6 +27,7 @@
 // Author: Brad Campbell <bradjc@virginia.edu>
 // Last modified: 11/07/2019
 
+use capsules_core::virtualizers::selection_policy::SelectionPolicy;
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use capsules_system::debug_writer::uart_debug_writer::UartDebugWriter;
 use core::mem::MaybeUninit;
@@ -55,8 +56,8 @@ const DEBUG_BUFFER_SPLIT: usize = 64;
 /// quick succession.
 #[macro_export]
 macro_rules! debug_writer_component_static {
-    ($BUF_SIZE_KB:expr) => {{
-        let uart = kernel::static_buf!(capsules_core::virtualizers::virtual_uart::UartDevice);
+    ($BUF_SIZE_KB:expr, $P: ty) => {{
+        let uart = kernel::static_buf!(capsules_core::virtualizers::virtual_uart::UartDevice<$P>);
         let ring = kernel::static_buf!(kernel::collections::ring_buffer::RingBuffer<'static, u8>);
         let buffer = kernel::static_buf!([u8; 1024 * $BUF_SIZE_KB]);
         let debug =
@@ -64,8 +65,20 @@ macro_rules! debug_writer_component_static {
 
         (uart, ring, buffer, debug)
     };};
+    ($P: ty) => {{
+        $crate::debug_writer_component_static!($crate::debug_writer::DEFAULT_DEBUG_BUFFER_KBYTE, $P)
+    };};
+    ($BUF_SIZE_KB:expr) => {{
+        $crate::debug_writer_component_static!(
+            $BUF_SIZE_KB,
+            capsules_core::virtualizers::selection_policy::InsertionFirstPolicy
+        )
+    };};
     () => {{
-        $crate::debug_writer_component_static!($crate::debug_writer::DEFAULT_DEBUG_BUFFER_KBYTE)
+        $crate::debug_writer_component_static!(
+            $crate::debug_writer::DEFAULT_DEBUG_BUFFER_KBYTE,
+            capsules_core::virtualizers::selection_policy::InsertionFirstPolicy
+        )
     };};
 }
 
@@ -92,20 +105,27 @@ macro_rules! debug_writer_no_mux_component_static {
 
 // Allow dead code because we need the `Chip` type but don't use `chip`.
 #[allow(dead_code)]
-pub struct DebugWriterComponent<const BUF_SIZE_BYTES: usize, C: SetDebugWriterCapability> {
-    uart_mux: &'static MuxUart<'static>,
+pub struct DebugWriterComponent<
+    const BUF_SIZE_BYTES: usize,
+    C: SetDebugWriterCapability,
+    P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static,
+> {
+    uart_mux: &'static MuxUart<'static, P>,
     marker: core::marker::PhantomData<[u8; BUF_SIZE_BYTES]>,
     capability: C,
 }
 
-impl<const BUF_SIZE_BYTES: usize, C: SetDebugWriterCapability>
-    DebugWriterComponent<BUF_SIZE_BYTES, C>
+impl<
+        const BUF_SIZE_BYTES: usize,
+        C: SetDebugWriterCapability,
+        SP: SelectionPolicy<&'static UartDevice<'static, SP>> + 'static,
+    > DebugWriterComponent<BUF_SIZE_BYTES, C, SP>
 {
     /// Create a debug writer component while binding the global variable used
     /// by debug.rs to the main thread.
     #[cfg(target_has_atomic = "ptr")]
     pub fn new<P: kernel::platform::chip::ThreadIdProvider>(
-        uart_mux: &'static MuxUart,
+        uart_mux: &'static MuxUart<SP>,
         capability: C,
     ) -> Self {
         kernel::debug::initialize_debug_writer_wrapper::<P>();
@@ -137,7 +157,11 @@ impl<const BUF_SIZE_BYTES: usize, C: SetDebugWriterCapability>
     ///      })
     /// .finalize(components::debug_writer_component_static!());
     /// ```
-    pub fn new_unsafe<F>(uart_mux: &'static MuxUart, capability: C, bind_debug_global: F) -> Self
+    pub fn new_unsafe<F>(
+        uart_mux: &'static MuxUart<SP>,
+        capability: C,
+        bind_debug_global: F,
+    ) -> Self
     where
         F: FnOnce(),
     {
@@ -154,11 +178,14 @@ impl<const BUF_SIZE_BYTES: usize, C: SetDebugWriterCapability>
 pub struct Capability;
 unsafe impl capabilities::ProcessManagementCapability for Capability {}
 
-impl<const BUF_SIZE_BYTES: usize, C: SetDebugWriterCapability> Component
-    for DebugWriterComponent<BUF_SIZE_BYTES, C>
+impl<
+        const BUF_SIZE_BYTES: usize,
+        C: SetDebugWriterCapability,
+        P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static,
+    > Component for DebugWriterComponent<BUF_SIZE_BYTES, C, P>
 {
     type StaticInput = (
-        &'static mut MaybeUninit<UartDevice<'static>>,
+        &'static mut MaybeUninit<UartDevice<'static, P>>,
         &'static mut MaybeUninit<RingBuffer<'static, u8>>,
         &'static mut MaybeUninit<[u8; BUF_SIZE_BYTES]>,
         &'static mut MaybeUninit<UartDebugWriter>,

--- a/boards/components/src/lldb.rs
+++ b/boards/components/src/lldb.rs
@@ -21,6 +21,7 @@
 // Last modified: 12/04/2019
 
 use capsules_core::low_level_debug::LowLevelDebug;
+use capsules_core::virtualizers::selection_policy::SelectionPolicy;
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
 use kernel::capabilities;
@@ -45,18 +46,18 @@ macro_rules! low_level_debug_component_static {
     };};
 }
 
-pub struct LowLevelDebugComponent {
+pub struct LowLevelDebugComponent<P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
-    uart_mux: &'static MuxUart<'static>,
+    uart_mux: &'static MuxUart<'static, P>,
 }
 
-impl LowLevelDebugComponent {
+impl<P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static> LowLevelDebugComponent<P> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-        uart_mux: &'static MuxUart,
-    ) -> LowLevelDebugComponent {
+        uart_mux: &'static MuxUart<P>,
+    ) -> LowLevelDebugComponent<P> {
         LowLevelDebugComponent {
             board_kernel,
             driver_num,
@@ -65,13 +66,15 @@ impl LowLevelDebugComponent {
     }
 }
 
-impl Component for LowLevelDebugComponent {
+impl<P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static> Component
+    for LowLevelDebugComponent<P>
+{
     type StaticInput = (
-        &'static mut MaybeUninit<UartDevice<'static>>,
+        &'static mut MaybeUninit<UartDevice<'static, P>>,
         &'static mut MaybeUninit<[u8; capsules_core::low_level_debug::BUF_LEN]>,
-        &'static mut MaybeUninit<LowLevelDebug<'static, UartDevice<'static>>>,
+        &'static mut MaybeUninit<LowLevelDebug<'static, UartDevice<'static, P>>>,
     );
-    type Output = &'static LowLevelDebug<'static, UartDevice<'static>>;
+    type Output = &'static LowLevelDebug<'static, UartDevice<'static, P>>;
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -19,6 +19,7 @@
 // Last modified: 6/20/2018
 
 use capsules_core::process_console::{self, ProcessConsole};
+use capsules_core::virtualizers::selection_policy::SelectionPolicy;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
@@ -30,9 +31,9 @@ use kernel::process::ProcessPrinter;
 
 #[macro_export]
 macro_rules! process_console_component_static {
-    ($A: ty, $COMMAND_HISTORY_LEN: expr $(,)?) => {{
+    ($A: ty, $P: ty, $COMMAND_HISTORY_LEN: expr $(,)?) => {{
         let alarm = kernel::static_buf!(capsules_core::virtualizers::virtual_alarm::VirtualMuxAlarm<'static, $A>);
-        let uart = kernel::static_buf!(capsules_core::virtualizers::virtual_uart::UartDevice);
+        let uart = kernel::static_buf!(capsules_core::virtualizers::virtual_uart::UartDevice<$P>);
         let pconsole = kernel::static_buf!(
             capsules_core::process_console::ProcessConsole<
                 $COMMAND_HISTORY_LEN,
@@ -60,29 +61,40 @@ macro_rules! process_console_component_static {
             pconsole,
         )
     };};
+    ($A: ty, $P: ty, $(,)?) => {{
+        $crate::process_console_component_static!($A, $P, { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN })
+    };};
     ($A: ty $(,)?) => {{
-        $crate::process_console_component_static!($A, { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN })
+        use capsules_core::virtualizers::selection_policy::InsertionFirstPolicy;
+        $crate::process_console_component_static!($A, InsertionFirstPolicy, { capsules_core::process_console::DEFAULT_COMMAND_HISTORY_LEN })
     };};
 }
 
-pub struct ProcessConsoleComponent<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> {
+pub struct ProcessConsoleComponent<
+    const COMMAND_HISTORY_LEN: usize,
+    A: 'static + Alarm<'static>,
+    P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static,
+> {
     board_kernel: &'static kernel::Kernel,
-    uart_mux: &'static MuxUart<'static>,
+    uart_mux: &'static MuxUart<'static, P>,
     alarm_mux: &'static MuxAlarm<'static, A>,
     process_printer: &'static dyn ProcessPrinter,
     reset_function: Option<fn() -> !>,
 }
 
-impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>>
-    ProcessConsoleComponent<COMMAND_HISTORY_LEN, A>
+impl<
+        const COMMAND_HISTORY_LEN: usize,
+        A: 'static + Alarm<'static>,
+        P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static,
+    > ProcessConsoleComponent<COMMAND_HISTORY_LEN, A, P>
 {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        uart_mux: &'static MuxUart,
+        uart_mux: &'static MuxUart<'static, P>,
         alarm_mux: &'static MuxAlarm<'static, A>,
         process_printer: &'static dyn ProcessPrinter,
         reset_function: Option<fn() -> !>,
-    ) -> ProcessConsoleComponent<COMMAND_HISTORY_LEN, A> {
+    ) -> ProcessConsoleComponent<COMMAND_HISTORY_LEN, A, P> {
         ProcessConsoleComponent {
             board_kernel,
             uart_mux,
@@ -111,12 +123,15 @@ pub struct Capability;
 unsafe impl capabilities::ProcessManagementCapability for Capability {}
 unsafe impl capabilities::ProcessStartCapability for Capability {}
 
-impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
-    for ProcessConsoleComponent<COMMAND_HISTORY_LEN, A>
+impl<
+        const COMMAND_HISTORY_LEN: usize,
+        A: 'static + Alarm<'static>,
+        P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static,
+    > Component for ProcessConsoleComponent<COMMAND_HISTORY_LEN, A, P>
 {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
-        &'static mut MaybeUninit<UartDevice<'static>>,
+        &'static mut MaybeUninit<UartDevice<'static, P>>,
         &'static mut MaybeUninit<[u8; capsules_core::process_console::WRITE_BUF_LEN]>,
         &'static mut MaybeUninit<[u8; capsules_core::process_console::READ_BUF_LEN]>,
         &'static mut MaybeUninit<[u8; capsules_core::process_console::QUEUE_BUF_LEN]>,

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -11,6 +11,7 @@
 #![no_std]
 #![no_main]
 
+use capsules_core::virtualizers::selection_policy::InsertionFirstPolicy;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use e310_g002::interrupt_service::E310G002DefaultPeripherals;
 use kernel::capabilities;
@@ -329,7 +330,10 @@ unsafe fn start() -> (
         uart_mux,
         create_capability!(capabilities::SetDebugWriterCapability),
     )
-    .finalize(components::debug_writer_component_static!(DEBUG_BUFFER_KB));
+    .finalize(components::debug_writer_component_static!(
+        DEBUG_BUFFER_KB,
+        InsertionFirstPolicy
+    ));
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/imix/src/test/virtual_uart_rx_test.rs
+++ b/boards/imix/src/test/virtual_uart_rx_test.rs
@@ -51,6 +51,7 @@
 use core::ptr::addr_of_mut;
 
 use capsules_core::test::virtual_uart::TestVirtualUartReceive;
+use capsules_core::virtualizers::selection_policy::InsertionFirstPolicy;
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use kernel::debug;
 use kernel::hil::uart::Receive;
@@ -66,12 +67,12 @@ pub unsafe fn run_virtual_uart_receive(mux: &'static MuxUart<'static>) {
 
 unsafe fn static_init_test_receive_small(
     mux: &'static MuxUart<'static>,
-) -> &'static TestVirtualUartReceive {
+) -> &'static TestVirtualUartReceive<InsertionFirstPolicy> {
     static mut SMALL: [u8; 3] = [0; 3];
     let device = static_init!(UartDevice<'static>, UartDevice::new(mux, true));
     device.setup();
     let test = static_init!(
-        TestVirtualUartReceive,
+        TestVirtualUartReceive<InsertionFirstPolicy>,
         TestVirtualUartReceive::new(device, &mut *addr_of_mut!(SMALL))
     );
     device.set_receive_client(test);
@@ -80,12 +81,12 @@ unsafe fn static_init_test_receive_small(
 
 unsafe fn static_init_test_receive_large(
     mux: &'static MuxUart<'static>,
-) -> &'static TestVirtualUartReceive {
+) -> &'static TestVirtualUartReceive<InsertionFirstPolicy> {
     static mut BUFFER: [u8; 7] = [0; 7];
     let device = static_init!(UartDevice<'static>, UartDevice::new(mux, true));
     device.setup();
     let test = static_init!(
-        TestVirtualUartReceive,
+        TestVirtualUartReceive<InsertionFirstPolicy>,
         TestVirtualUartReceive::new(device, &mut *addr_of_mut!(BUFFER))
     );
     device.set_receive_client(test);

--- a/boards/nucleo_f446re/src/virtual_uart_rx_test.rs
+++ b/boards/nucleo_f446re/src/virtual_uart_rx_test.rs
@@ -51,6 +51,7 @@
 use core::ptr::addr_of_mut;
 
 use capsules_core::test::virtual_uart::TestVirtualUartReceive;
+use capsules_core::virtualizers::selection_policy::InsertionFirstPolicy;
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use kernel::debug;
 use kernel::hil::uart::Receive;
@@ -66,12 +67,12 @@ pub unsafe fn run_virtual_uart_receive(mux: &'static MuxUart<'static>) {
 
 unsafe fn static_init_test_receive_small(
     mux: &'static MuxUart<'static>,
-) -> &'static TestVirtualUartReceive {
+) -> &'static TestVirtualUartReceive<InsertionFirstPolicy> {
     static mut SMALL: [u8; 3] = [0; 3];
     let device = static_init!(UartDevice<'static>, UartDevice::new(mux, true));
     device.setup();
     let test = static_init!(
-        TestVirtualUartReceive,
+        TestVirtualUartReceive<InsertionFirstPolicy>,
         TestVirtualUartReceive::new(device, &mut *addr_of_mut!(SMALL))
     );
     device.set_receive_client(test);
@@ -80,12 +81,12 @@ unsafe fn static_init_test_receive_small(
 
 unsafe fn static_init_test_receive_large(
     mux: &'static MuxUart<'static>,
-) -> &'static TestVirtualUartReceive {
+) -> &'static TestVirtualUartReceive<InsertionFirstPolicy> {
     static mut BUFFER: [u8; 7] = [0; 7];
     let device = static_init!(UartDevice<'static>, UartDevice::new(mux, true));
     device.setup();
     let test = static_init!(
-        TestVirtualUartReceive,
+        TestVirtualUartReceive<InsertionFirstPolicy>,
         TestVirtualUartReceive::new(device, &mut *addr_of_mut!(BUFFER))
     );
     device.set_receive_client(test);

--- a/boards/qemu_rv32_virt/src/lib.rs
+++ b/boards/qemu_rv32_virt/src/lib.rs
@@ -7,6 +7,8 @@
 #![no_std]
 #![no_main]
 
+// Uncomment if you want to use Round Robin policy for UART virtualizer.
+// use capsules_core::virtualizers::selection_policy::RoundRobinPolicy;
 use capsules_core::virtualizers::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::capabilities;
 use kernel::component::Component;
@@ -59,6 +61,8 @@ pub struct QemuRv32VirtPlatform {
     lldb: &'static capsules_core::low_level_debug::LowLevelDebug<
         'static,
         capsules_core::virtualizers::virtual_uart::UartDevice<'static>,
+        // Uncomment if you want to use Round Robin policy.
+        // capsules_core::virtualizers::virtual_uart::UartDevice<'static, RoundRobinPolicy>,
     >,
     alarm: &'static capsules_core::alarm::AlarmDriver<
         'static,
@@ -259,6 +263,16 @@ pub unsafe fn start() -> (
     // UART.
     let uart_mux = components::console::UartMuxComponent::new(&peripherals.uart0, 115200)
         .finalize(components::uart_mux_component_static!());
+
+    // Uncomment if you want to use Round Robin policy.
+    // let uart_mux = components::console::UartMuxComponent::new_with_policy(
+    //     &peripherals.uart0,
+    //     115200,
+    //     capsules_core::virtualizers::selection_policy::RoundRobinPolicy::default(),
+    // )
+    // .finalize(components::uart_mux_component_static!(
+    //     capsules_core::virtualizers::selection_policy::RoundRobinPolicy
+    // ));
 
     // Use the RISC-V machine timer timesource
     let hardware_timer = static_init!(
@@ -655,7 +669,9 @@ pub unsafe fn start() -> (
         None,
     )
     .finalize(components::process_console_component_static!(
-        qemu_rv32_virt_chip::chip::QemuRv32VirtClint
+        qemu_rv32_virt_chip::chip::QemuRv32VirtClint,
+        // Uncomment if you want to use Round Robin policy.
+        // capsules_core::virtualizers::selection_policy::RoundRobinPolicy,
     ));
 
     // Setup the console.
@@ -664,7 +680,10 @@ pub unsafe fn start() -> (
         capsules_core::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_static!());
+    .finalize(components::console_component_static!(
+        // Uncomment if you want to use Round Robin policy.
+        // capsules_core::virtualizers::selection_policy::RoundRobinPolicy
+    ));
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new::<
         <ChipHw as kernel::platform::chip::Chip>::ThreadIdProvider,

--- a/boards/stm32f3discovery/src/virtual_uart_rx_test.rs
+++ b/boards/stm32f3discovery/src/virtual_uart_rx_test.rs
@@ -51,6 +51,7 @@
 use core::ptr::addr_of_mut;
 
 use capsules_core::test::virtual_uart::TestVirtualUartReceive;
+use capsules_core::virtualizers::selection_policy::InsertionFirstPolicy;
 use capsules_core::virtualizers::virtual_uart::{MuxUart, UartDevice};
 use kernel::debug;
 use kernel::hil::uart::Receive;
@@ -66,12 +67,12 @@ pub unsafe fn run_virtual_uart_receive(mux: &'static MuxUart<'static>) {
 
 unsafe fn static_init_test_receive_small(
     mux: &'static MuxUart<'static>,
-) -> &'static TestVirtualUartReceive {
+) -> &'static TestVirtualUartReceive<InsertionFirstPolicy> {
     static mut SMALL: [u8; 3] = [0; 3];
     let device = static_init!(UartDevice<'static>, UartDevice::new(mux, true));
     device.setup();
     let test = static_init!(
-        TestVirtualUartReceive,
+        TestVirtualUartReceive<InsertionFirstPolicy>,
         TestVirtualUartReceive::new(device, &mut *addr_of_mut!(SMALL))
     );
     device.set_receive_client(test);
@@ -80,12 +81,12 @@ unsafe fn static_init_test_receive_small(
 
 unsafe fn static_init_test_receive_large(
     mux: &'static MuxUart<'static>,
-) -> &'static TestVirtualUartReceive {
+) -> &'static TestVirtualUartReceive<InsertionFirstPolicy> {
     static mut BUFFER: [u8; 7] = [0; 7];
     let device = static_init!(UartDevice<'static>, UartDevice::new(mux, true));
     device.setup();
     let test = static_init!(
-        TestVirtualUartReceive,
+        TestVirtualUartReceive<InsertionFirstPolicy>,
         TestVirtualUartReceive::new(device, &mut *addr_of_mut!(BUFFER))
     );
     device.set_receive_client(test);

--- a/capsules/core/README.md
+++ b/capsules/core/README.md
@@ -71,6 +71,7 @@ These allow for multiple users of shared hardware resources in the kernel.
 - **[Virtual SPI](src/virtualizers/virtual_spi.rs)**: Shared SPI and fixed chip select pins.
 - **[Virtual Timer](src/virtualizers/virtual_timer.rs)**: Shared timer.
 - **[Virtual UART](src/virtualizers/virtual_uart.rs)**: Shared UART bus.
+- **[Selection Policy](src/virtualizers/selection_policy.rs)**: Policy that determines in what order the virtual peripherals are selected for execution.
 
 Miscallenous Capsules & Infrastructure
 --------------------------------------

--- a/capsules/core/src/test/virtual_uart.rs
+++ b/capsules/core/src/test/virtual_uart.rs
@@ -4,6 +4,7 @@
 
 //! Test reception on the virtualized UART: best if multiple Tests are
 //! instantiated and tested in parallel.
+use crate::virtualizers::selection_policy::SelectionPolicy;
 use crate::virtualizers::virtual_uart::UartDevice;
 
 use kernel::debug;
@@ -12,13 +13,13 @@ use kernel::hil::uart::Receive;
 use kernel::utilities::cells::TakeCell;
 use kernel::ErrorCode;
 
-pub struct TestVirtualUartReceive {
-    device: &'static UartDevice<'static>,
+pub struct TestVirtualUartReceive<P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static> {
+    device: &'static UartDevice<'static, P>,
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl TestVirtualUartReceive {
-    pub fn new(device: &'static UartDevice<'static>, buffer: &'static mut [u8]) -> Self {
+impl<P: SelectionPolicy<&'static UartDevice<'static, P>>> TestVirtualUartReceive<P> {
+    pub fn new(device: &'static UartDevice<'static, P>, buffer: &'static mut [u8]) -> Self {
         TestVirtualUartReceive {
             device,
             buffer: TakeCell::new(buffer),
@@ -35,7 +36,9 @@ impl TestVirtualUartReceive {
     }
 }
 
-impl uart::ReceiveClient for TestVirtualUartReceive {
+impl<P: SelectionPolicy<&'static UartDevice<'static, P>> + 'static> uart::ReceiveClient
+    for TestVirtualUartReceive<P>
+{
     fn received_buffer(
         &self,
         rx_buffer: &'static mut [u8],

--- a/capsules/core/src/virtualizers/mod.rs
+++ b/capsules/core/src/virtualizers/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2023.
 
+pub mod selection_policy;
 pub mod virtual_adc;
 pub mod virtual_aes_ccm;
 pub mod virtual_alarm;

--- a/capsules/core/src/virtualizers/selection_policy.rs
+++ b/capsules/core/src/virtualizers/selection_policy.rs
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright OxidOS Automotive SRL 2026.
+
+//! Selection Policy that determines which device to choose first in the virtualizer.
+
+use core::cell::Cell;
+
+/// Trait that determines which device to choose first
+/// from the list of devices in the virtualizer.
+pub trait SelectionPolicy<I> {
+    /// Function that selects the device from the list based on the predicate.
+    fn select<It>(&self, it: It, ready: impl Fn(&I) -> bool) -> Option<I>
+    where
+        It: Iterator<Item = I> + Clone;
+}
+
+/// Default policy which selects the first ready device starting from the beginning of the list.
+pub struct InsertionFirstPolicy;
+
+impl<I> SelectionPolicy<I> for InsertionFirstPolicy {
+    fn select<It>(&self, mut it: It, ready: impl Fn(&I) -> bool) -> Option<I>
+    where
+        It: Iterator<Item = I>,
+    {
+        it.find(|node| ready(node))
+    }
+}
+
+/// Round Robin policy which selects the first ready device based on the last access position.
+/// It stores the position of the last selected device to introduce fairness.
+pub struct RoundRobinPolicy {
+    last_access_position: Cell<usize>,
+}
+
+impl<I> SelectionPolicy<I> for RoundRobinPolicy {
+    fn select<It>(&self, it: It, ready: impl Fn(&I) -> bool) -> Option<I>
+    where
+        It: Iterator<Item = I> + Clone,
+    {
+        it.clone()
+            .enumerate()
+            .skip(self.last_access_position.get() + 1)
+            .chain(it.enumerate().take(self.last_access_position.get()))
+            .find(|(_, node)| ready(node))
+            .map(|(index, node)| {
+                self.last_access_position.set(index);
+                node
+            })
+    }
+}
+
+impl Default for RoundRobinPolicy {
+    fn default() -> Self {
+        Self {
+            last_access_position: Cell::new(0),
+        }
+    }
+}

--- a/capsules/core/src/virtualizers/virtual_uart.rs
+++ b/capsules/core/src/virtualizers/virtual_uart.rs
@@ -54,19 +54,22 @@ use kernel::hil::uart;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
+use crate::virtualizers::selection_policy::{InsertionFirstPolicy, SelectionPolicy};
+
 pub const RX_BUF_LEN: usize = 64;
 
-pub struct MuxUart<'a> {
+pub struct MuxUart<'a, P: SelectionPolicy<&'a UartDevice<'a, P>> = InsertionFirstPolicy> {
     uart: &'a dyn uart::Uart<'a>,
     speed: u32,
-    devices: List<'a, UartDevice<'a>>,
-    inflight: OptionalCell<&'a UartDevice<'a>>,
+    devices: List<'a, UartDevice<'a, P>>,
+    inflight: OptionalCell<&'a UartDevice<'a, P>>,
     buffer: TakeCell<'static, [u8]>,
     completing_read: Cell<bool>,
     deferred_call: DeferredCall,
+    selection_policy: P,
 }
 
-impl uart::TransmitClient for MuxUart<'_> {
+impl<'a, P: SelectionPolicy<&'a UartDevice<'a, P>>> uart::TransmitClient for MuxUart<'a, P> {
     fn transmitted_buffer(
         &self,
         tx_buffer: &'static mut [u8],
@@ -81,7 +84,7 @@ impl uart::TransmitClient for MuxUart<'_> {
     }
 }
 
-impl uart::ReceiveClient for MuxUart<'_> {
+impl<'a, P: SelectionPolicy<&'a UartDevice<'a, P>>> uart::ReceiveClient for MuxUart<'a, P> {
     fn received_buffer(
         &self,
         buffer: &'static mut [u8],
@@ -210,8 +213,13 @@ impl uart::ReceiveClient for MuxUart<'_> {
     }
 }
 
-impl<'a> MuxUart<'a> {
-    pub fn new(uart: &'a dyn uart::Uart<'a>, buffer: &'static mut [u8], speed: u32) -> MuxUart<'a> {
+impl<'a, P: SelectionPolicy<&'a UartDevice<'a, P>>> MuxUart<'a, P> {
+    /// Create a new Mux with the [`InsertionFirstPolicy`] selection policy.
+    pub fn new(
+        uart: &'a dyn uart::Uart<'a>,
+        buffer: &'static mut [u8],
+        speed: u32,
+    ) -> MuxUart<'a, InsertionFirstPolicy> {
         MuxUart {
             uart,
             speed,
@@ -220,6 +228,31 @@ impl<'a> MuxUart<'a> {
             buffer: TakeCell::new(buffer),
             completing_read: Cell::new(false),
             deferred_call: DeferredCall::new(),
+            selection_policy: InsertionFirstPolicy,
+        }
+    }
+
+    /// Create a new Mux with a custom selection policy.
+    /// It determines which device will be selected next
+    /// from the list of devices in the virtualizer.
+    ///
+    /// For the default implementation, please refer to [`MuxUart::new`] function
+    /// which uses [`InsertionFirstPolicy`] selection policy.
+    pub fn new_with_policy(
+        uart: &'a dyn uart::Uart<'a>,
+        buffer: &'static mut [u8],
+        speed: u32,
+        selection_policy: P,
+    ) -> MuxUart<'a, P> {
+        MuxUart {
+            uart,
+            speed,
+            devices: List::new(),
+            inflight: OptionalCell::empty(),
+            buffer: TakeCell::new(buffer),
+            completing_read: Cell::new(false),
+            deferred_call: DeferredCall::new(),
+            selection_policy,
         }
     }
 
@@ -235,7 +268,13 @@ impl<'a> MuxUart<'a> {
 
     fn do_next_op(&self) {
         if self.inflight.is_none() {
-            let mnode = self.devices.iter().find(|node| node.operation.is_some());
+            // Selection policy determines how to choose a ready device
+            // from the list based on the predicate.
+            let mnode = self
+                .selection_policy
+                .select(self.devices.iter(), |uart_device| {
+                    uart_device.operation.is_some()
+                });
             mnode.map(|node| {
                 node.tx_buffer.take().map(|buf| {
                     node.operation.take().map(move |op| match op {
@@ -313,7 +352,7 @@ impl<'a> MuxUart<'a> {
     }
 }
 
-impl DeferredCallClient for MuxUart<'_> {
+impl<'a, P: SelectionPolicy<&'a UartDevice<'a, P>>> DeferredCallClient for MuxUart<'a, P> {
     fn handle_deferred_call(&self) {
         self.do_next_op();
     }
@@ -336,9 +375,9 @@ enum UartDeviceReceiveState {
     Aborting,
 }
 
-pub struct UartDevice<'a> {
+pub struct UartDevice<'a, P: SelectionPolicy<&'a Self> = InsertionFirstPolicy> {
     state: Cell<UartDeviceReceiveState>,
-    mux: &'a MuxUart<'a>,
+    mux: &'a MuxUart<'a, P>,
     receiver: bool, // Whether or not to pass this UartDevice incoming messages.
     tx_buffer: TakeCell<'static, [u8]>,
     transmitting: Cell<bool>,
@@ -346,13 +385,13 @@ pub struct UartDevice<'a> {
     rx_position: Cell<usize>,
     rx_len: Cell<usize>,
     operation: OptionalCell<Operation>,
-    next: ListLink<'a, UartDevice<'a>>,
+    next: ListLink<'a, UartDevice<'a, P>>,
     rx_client: OptionalCell<&'a dyn uart::ReceiveClient>,
     tx_client: OptionalCell<&'a dyn uart::TransmitClient>,
 }
 
-impl<'a> UartDevice<'a> {
-    pub fn new(mux: &'a MuxUart<'a>, receiver: bool) -> UartDevice<'a> {
+impl<'a, P: SelectionPolicy<&'a Self>> UartDevice<'a, P> {
+    pub fn new(mux: &'a MuxUart<'a, P>, receiver: bool) -> UartDevice<'a, P> {
         UartDevice {
             state: Cell::new(UartDeviceReceiveState::Idle),
             mux,
@@ -375,7 +414,7 @@ impl<'a> UartDevice<'a> {
     }
 }
 
-impl uart::TransmitClient for UartDevice<'_> {
+impl<'a, P: SelectionPolicy<&'a Self>> uart::TransmitClient for UartDevice<'a, P> {
     fn transmitted_buffer(
         &self,
         tx_buffer: &'static mut [u8],
@@ -395,7 +434,7 @@ impl uart::TransmitClient for UartDevice<'_> {
         });
     }
 }
-impl uart::ReceiveClient for UartDevice<'_> {
+impl<'a, P: SelectionPolicy<&'a Self>> uart::ReceiveClient for UartDevice<'a, P> {
     fn received_buffer(
         &self,
         rx_buffer: &'static mut [u8],
@@ -410,13 +449,13 @@ impl uart::ReceiveClient for UartDevice<'_> {
     }
 }
 
-impl<'a> ListNode<'a, UartDevice<'a>> for UartDevice<'a> {
-    fn next(&'a self) -> &'a ListLink<'a, UartDevice<'a>> {
+impl<'a, P: SelectionPolicy<&'a Self>> ListNode<'a, UartDevice<'a, P>> for UartDevice<'a, P> {
+    fn next(&'a self) -> &'a ListLink<'a, UartDevice<'a, P>> {
         &self.next
     }
 }
 
-impl<'a> uart::Transmit<'a> for UartDevice<'a> {
+impl<'a, P: SelectionPolicy<&'a Self>> uart::Transmit<'a> for UartDevice<'a, P> {
     fn set_transmit_client(&self, client: &'a dyn uart::TransmitClient) {
         self.tx_client.set(client);
     }
@@ -456,7 +495,7 @@ impl<'a> uart::Transmit<'a> for UartDevice<'a> {
     }
 }
 
-impl<'a> uart::Receive<'a> for UartDevice<'a> {
+impl<'a, P: SelectionPolicy<&'a Self>> uart::Receive<'a> for UartDevice<'a, P> {
     fn set_receive_client(&self, client: &'a dyn uart::ReceiveClient) {
         self.rx_client.set(client);
     }

--- a/kernel/src/collections/list.rs
+++ b/kernel/src/collections/list.rs
@@ -26,6 +26,16 @@ pub struct ListIterator<'a, T: 'a + ?Sized + ListNode<'a, T>> {
     cur: Option<&'a T>,
 }
 
+// Since `ListIterator` stores a reference of T, it is safe to implement `Clone`
+// for `ListIterator` so that several iterators can be made out of one.
+//
+// This is useful for the [`SelectionPolicy`] implementations.
+impl<'a, T: ?Sized + ListNode<'a, T>> Clone for ListIterator<'a, T> {
+    fn clone(&self) -> Self {
+        Self { cur: self.cur }
+    }
+}
+
 impl<'a, T: ?Sized + ListNode<'a, T>> Iterator for ListIterator<'a, T> {
     type Item = &'a T;
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the fairness problem of virtual devices. So far it only implements it for the UART Mux, but if approved, the same fix will be easily implemented for the rest of the affected Muxes. 

#### The Fairness Problem

When searching for the next operation, multiplexers (except the Alarm) will always iterate the devices list from beginning to end. This means that if one device always has a job and it was inserted earlier, it will always be picked.

The following examples illustrates the problem for the UART Mux. If `debug!()` is called frequently (for example in the `UartMux`), the `DebugConsole` has a monopoly over the UART Multiplexer, as it will be the only devices chosen to print.


<img width="1334" height="900" alt="insertion_first" src="https://github.com/user-attachments/assets/86f4af0a-691e-4d42-b8aa-bd7d91bb49e7" />

#### Solution

We introduce the `SelectionPolicy` trait that provides Muxes with the device selection logic. It is a generic type and should not add any overhead, neither in speed, neither in code space.

We define two policies:
- `InsertionFirstPolicy` that behaves like Muxes used to behave so far, it iterates the list from the beginning to the end. This provides backward compatibility.
- `RoundRobinPolicy` that iterates the devices list in a round robin manner. Using this policy with the previous `debug!` examples allows all device to print.

<img width="1184" height="885" alt="round_robin" src="https://github.com/user-attachments/assets/90bb24a5-057b-4090-931c-38a9240a1853" />

This solution offers a structural change that gives users the freedom to choose the policy they want. By default, the UART Mux uses the `InsertionFirstPolicy` and there are no changes required in the code. 

Users will now able to implement their own selection policies for the UART Mux.

### Testing Strategy

This pull request was tested by using a custom kernel of `qemu_rv32_virt` with UART peripheral, and three equivalent applications that try to use `printf()` simultaneously.


### TODO or Help Wanted

Feedback


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

We are unsure of the proper placement of the documentation in the `README` file. Help is needed here as well.

### Formatting

- [X] Ran `make prepush`.

### AI Use

- [ ] The PR description details my use of AI in the production of the
      code in this PR, if any, and I have manually checked and
      personally certify the entire contents of this PR.
