### PR TITLE
Check duplicates in a LinkedList

### DIFF
--- a/kernel/src/collections/list.rs
+++ b/kernel/src/collections/list.rs
@@ -2,34 +2,89 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright Tock Contributors 2022.
 
-//! Linked list implementation.
+//! Intrusive singly linked list implementation.
+//!
+//! A node's link has three possible states:
+//!
+//! - [`LinkState::Unlinked`]: the node is not in a list.
+//! - [`LinkState::Tail`]: the node is linked and is the last node.
+//! - [`LinkState::Next`]: the node is linked and has a successor.
+//!
+//! Distinguishing `Unlinked` from `Tail` is necessary because neither state
+//! has a successor, but only an unlinked node may be inserted into a list.
 
 use core::cell::Cell;
 
-/// Compare two(possibly unsized) references by data address only, ignoring
-/// any pointer metadata such as vtable pointer
+use crate::ErrorCode;
+
+/// Compare two possibly unsized references by data address only, ignoring
+/// pointer metadata such as a vtable pointer.
 fn same_node<T: ?Sized>(a: &T, b: &T) -> bool {
     let a: *const T = a;
     let b: *const T = b;
+
     core::ptr::eq(a.cast::<()>(), b.cast::<()>())
 }
 
-pub struct ListLink<'a, T: 'a + ?Sized>(Cell<Option<&'a T>>);
+/// Internal state of a node's list link.
+enum LinkState<'a, T: 'a + ?Sized> {
+    /// The node is not currently linked in any list.
+    Unlinked,
 
-impl<'a, T: ?Sized> ListLink<'a, T> {
-    pub const fn empty() -> ListLink<'a, T> {
-        ListLink(Cell::new(None))
+    /// The node is linked and is the final node in its list.
+    Tail,
+
+    /// The node is linked and points to its successor.
+    Next(&'a T),
+}
+
+impl<T: ?Sized> Copy for LinkState<'_, T> {}
+
+impl<T: ?Sized> Clone for LinkState<'_, T> {
+    fn clone(&self) -> Self {
+        *self
     }
 }
 
-pub trait ListNode<'a, T: ?Sized> {
+/// Link embedded in every node stored in a [`List`].
+pub struct ListLink<'a, T: 'a + ?Sized>(Cell<LinkState<'a, T>>);
+
+impl<T: ?Sized> ListLink<'_, T> {
+    /// Creates an unlinked list link.
+    pub const fn empty() -> Self {
+        Self(Cell::new(LinkState::Unlinked))
+    }
+
+    /// Returns whether the owning node is linked in a list.
+    ///
+    /// A tail node is linked even though it has no successor.
+    pub fn is_linked(&self) -> bool {
+        !matches!(self.0.get(), LinkState::Unlinked)
+    }
+}
+
+/// Trait implemented by nodes that can be stored in a [`List`].
+pub trait ListNode<'a, T: ?Sized + 'a> {
+    /// Returns this node's embedded list link.
+    ///
+    /// Implementations must always return the same [`ListLink`] instance for
+    /// a particular node.
     fn next(&'a self) -> &'a ListLink<'a, T>;
+
+    /// Returns whether this node is linked in any list.
+    ///
+    /// This does not determine which particular list contains the node.
+    fn is_linked(&'a self) -> bool {
+        self.next().is_linked()
+    }
 }
 
+/// Intrusive singly linked list.
 pub struct List<'a, T: 'a + ?Sized + ListNode<'a, T>> {
-    head: ListLink<'a, T>,
+    head: Cell<Option<&'a T>>,
 }
 
+/// Iterator over a [`List`].
 pub struct ListIterator<'a, T: 'a + ?Sized + ListNode<'a, T>> {
     cur: Option<&'a T>,
 }
@@ -37,107 +92,209 @@ pub struct ListIterator<'a, T: 'a + ?Sized + ListNode<'a, T>> {
 impl<'a, T: ?Sized + ListNode<'a, T>> Iterator for ListIterator<'a, T> {
     type Item = &'a T;
 
-    fn next(&mut self) -> Option<&'a T> {
-        let cur = self.cur?;
-        self.cur = match cur.next().0.get() {
-            // A self-link marks the tail
-            Some(n) if same_node(n, cur) => None,
-            other => other,
-        };
-        Some(cur)
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.cur {
+            Some(node) => {
+                self.cur = match node.next().0.get() {
+                    LinkState::Next(next) => Some(next),
+                    LinkState::Tail | LinkState::Unlinked => None,
+                };
+
+                Some(node)
+            }
+
+            None => None,
+        }
     }
 }
 
 impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
-    pub const fn new() -> List<'a, T> {
-        List {
-            head: ListLink(Cell::new(None)),
+    /// Creates an empty list.
+    pub const fn new() -> Self {
+        Self {
+            head: Cell::new(None),
         }
     }
 
+    /// Returns the first node in the list.
     pub fn head(&self) -> Option<&'a T> {
-        self.head.0.get()
+        self.head.get()
     }
 
-    /// Returns `Err(()) if the node is already in a list`
-    pub fn is_linked(node: &'a T) -> bool {
-        node.next().0.get().is_some()
-    }
+    /// Inserts `node` at the beginning of the list after checking that it is
+    /// not already linked.
+    ///
+    /// Returns [`ErrorCode::ALREADY`] if `node` is already linked in this or
+    /// another list.
+    pub fn try_push_head(&self, node: &'a T) -> Result<(), ErrorCode> {
+        if node.is_linked() {
+            return Err(ErrorCode::ALREADY);
+        }
 
-    pub fn push_head(&self, node: &'a T) -> Result<(), ()> {
-        if Self::is_linked(node) {
-            return Err(());
+        // SAFETY: The check above established that `node` is unlinked.
+        unsafe {
+            self.push_head(node);
         }
-        match self.head.0.get() {
-            Some(h) => node.next().0.set(Some(h)),
-            // Empty list: `node` becomes the tail, so it links to itself
-            None => node.next().0.set(Some(node)),
-        }
-        self.head.0.set(Some(node));
+
         Ok(())
     }
 
-    pub fn push_tail(&self, node: &'a T) -> Result<(), ()> {
-        if Self::is_linked(node) {
-            return Err(());
-        }
-
-        node.next().0.set(Some(node));
-        match self.iter().last() {
-            Some(last) => last.next().0.set(Some(node)),
-            None => self.head.0.set(Some(node)),
-        }
-        Ok(())
-    }
-
-    pub fn pop_head(&self) -> Option<&'a T> {
-        let node = self.head.0.get()?;
-        self.head.0.set(match node.next().0.get() {
-            Some(n) if same_node(n, node) => None,
-            other => other,
+    /// Inserts `node` at the beginning of the list without checking whether
+    /// it is already linked.
+    ///
+    /// This preserves the behavior of the original `push_head()` operation,
+    /// but makes its required invariant explicit.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `node` is not currently linked in this
+    /// list or any other list.
+    ///
+    /// Inserting an already-linked node can corrupt list structure, create a
+    /// cycle, or cause nodes to become unreachable through their original
+    /// list.
+    pub unsafe fn push_head(&self, node: &'a T) {
+        node.next().0.set(match self.head.get() {
+            Some(head) => LinkState::Next(head),
+            None => LinkState::Tail,
         });
-        // Restoring the invariant for the returned node
-        node.next().0.set(None);
+
+        self.head.set(Some(node));
+    }
+
+    /// Inserts `node` at the end of the list after checking that it is not
+    /// already linked.
+    ///
+    /// Returns [`ErrorCode::ALREADY`] if `node` is already linked in this or
+    /// another list.
+    pub fn try_push_tail(&self, node: &'a T) -> Result<(), ErrorCode> {
+        if node.is_linked() {
+            return Err(ErrorCode::ALREADY);
+        }
+
+        // SAFETY: The check above established that `node` is unlinked.
+        unsafe {
+            self.push_tail(node);
+        }
+
+        Ok(())
+    }
+
+    /// Inserts `node` at the end of the list without checking whether it is
+    /// already linked.
+    ///
+    /// This preserves the behavior of the original `push_tail()` operation,
+    /// but makes its required invariant explicit.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `node` is not currently linked in this
+    /// list or any other list.
+    ///
+    /// Inserting an already-linked node can corrupt list structure, create a
+    /// cycle, or cause nodes to become unreachable through their original
+    /// list.
+    pub unsafe fn push_tail(&self, node: &'a T) {
+        // The inserted node becomes the new tail.
+        node.next().0.set(LinkState::Tail);
+
+        match self.iter().last() {
+            Some(last) => {
+                last.next().0.set(LinkState::Next(node));
+            }
+
+            None => {
+                self.head.set(Some(node));
+            }
+        }
+    }
+
+    /// Removes and returns the first node in the list.
+    ///
+    /// The returned node is restored to the unlinked state and can therefore
+    /// be inserted into a list again.
+    pub fn pop_head(&self) -> Option<&'a T> {
+        let node = self.head.get()?;
+
+        self.head.set(match node.next().0.get() {
+            LinkState::Next(next) => Some(next),
+            LinkState::Tail => None,
+
+            // A reachable list node must not be unlinked. Treat this as the
+            // end of the list if the invariant has been violated.
+            LinkState::Unlinked => None,
+        });
+
+        node.next().0.set(LinkState::Unlinked);
+
         Some(node)
     }
 
-    /// Unlinks `node` if it is a member of *this* list.
+    /// Unlinks `node` if it is a member of this list.
+    ///
+    /// Returns `true` if the node was found and removed.
     pub fn remove(&self, node: &'a T) -> bool {
-        if !Self::is_linked(node) {
+        // This only rejects a node that is definitely unlinked. A linked node
+        // might belong to another list, so membership must still be verified
+        // by traversing this list.
+        if !node.is_linked() {
             return false;
         }
-        let head = match self.head.0.get() {
-            Some(h) => h,
+
+        let head = match self.head.get() {
+            Some(head) => head,
             None => return false,
         };
+
         if same_node(head, node) {
             self.pop_head();
             return true;
         }
-        let mut prev = head;
-        while let Some(cur) = {
-            match prev.next().0.get() {
-                Some(n) if same_node(n, prev) => None,
-                other => other,
-            }
-        } {
-            if same_node(cur, node) {
-                // If `node` was the tail, `prev` becomes the new tail.
-                prev.next().0.set(match cur.next().0.get() {
-                    Some(n) if same_node(n, cur) => Some(prev),
-                    other => other,
-                });
-                node.next().0.set(None);
+
+        let mut previous = head;
+
+        while let LinkState::Next(current) = previous.next().0.get() {
+            if same_node(current, node) {
+                match current.next().0.get() {
+                    LinkState::Next(next) => {
+                        // Remove a middle node by linking its predecessor
+                        // directly to its successor.
+                        previous.next().0.set(LinkState::Next(next));
+                    }
+
+                    LinkState::Tail => {
+                        // Removing the final node makes its predecessor the
+                        // new tail.
+                        previous.next().0.set(LinkState::Tail);
+                    }
+
+                    LinkState::Unlinked => {
+                        // A node reachable from this list cannot legitimately
+                        // be unlinked.
+                        return false;
+                    }
+                }
+
+                current.next().0.set(LinkState::Unlinked);
                 return true;
             }
-            prev = cur;
+
+            previous = current;
         }
+
         false
     }
 
+    /// Returns an iterator from the head to the tail.
     pub fn iter(&self) -> ListIterator<'a, T> {
         ListIterator {
-            cur: self.head.0.get(),
+            cur: self.head.get(),
         }
+    }
+}
+
+impl<'a, T: ?Sized + ListNode<'a, T>> Default for List<'a, T> {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/kernel/src/collections/list.rs
+++ b/kernel/src/collections/list.rs
@@ -17,17 +17,12 @@ use core::cell::Cell;
 
 use crate::ErrorCode;
 
-/// Compare two possibly unsized references by data address only, ignoring
-/// pointer metadata such as a vtable pointer.
-fn same_node<T: ?Sized>(a: &T, b: &T) -> bool {
-    let a: *const T = a;
-    let b: *const T = b;
-
-    core::ptr::eq(a.cast::<()>(), b.cast::<()>())
-}
-
 /// Internal state of a node's list link.
-enum LinkState<'a, T: 'a + ?Sized> {
+#[derive(Clone, Copy)]
+enum LinkState<'a, T: 'a + ?Sized>
+where
+    T: Copy,
+{
     /// The node is not currently linked in any list.
     Unlinked,
 
@@ -36,14 +31,6 @@ enum LinkState<'a, T: 'a + ?Sized> {
 
     /// The node is linked and points to its successor.
     Next(&'a T),
-}
-
-impl<T: ?Sized> Copy for LinkState<'_, T> {}
-
-impl<T: ?Sized> Clone for LinkState<'_, T> {
-    fn clone(&self) -> Self {
-        *self
-    }
 }
 
 /// Link embedded in every node stored in a [`List`].
@@ -92,7 +79,7 @@ pub struct ListIterator<'a, T: 'a + ?Sized + ListNode<'a, T>> {
 impl<'a, T: ?Sized + ListNode<'a, T>> Iterator for ListIterator<'a, T> {
     type Item = &'a T;
 
-    fn next(&mut self) -> Option<Self::Item> {
+    fn next(&mut self) -> Option<&'a T> {
         match self.cur {
             Some(node) => {
                 self.cur = match node.next().0.get() {
@@ -133,7 +120,7 @@ impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
 
         // SAFETY: The check above established that `node` is unlinked.
         unsafe {
-            self.push_head(node);
+            self.push_head_unchecked(node);
         }
 
         Ok(())
@@ -147,13 +134,12 @@ impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
     ///
     /// # Safety
     ///
-    /// The caller must ensure that `node` is not currently linked in this
-    /// list or any other list.
+    /// The caller must ensure that `node` is not currently linked in a list
     ///
     /// Inserting an already-linked node can corrupt list structure, create a
     /// cycle, or cause nodes to become unreachable through their original
     /// list.
-    pub unsafe fn push_head(&self, node: &'a T) {
+    pub unsafe fn push_head_unchecked(&self, node: &'a T) {
         node.next().0.set(match self.head.get() {
             Some(head) => LinkState::Next(head),
             None => LinkState::Tail,
@@ -174,7 +160,7 @@ impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
 
         // SAFETY: The check above established that `node` is unlinked.
         unsafe {
-            self.push_tail(node);
+            self.push_tail_unchecked(node);
         }
 
         Ok(())
@@ -188,13 +174,12 @@ impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
     ///
     /// # Safety
     ///
-    /// The caller must ensure that `node` is not currently linked in this
-    /// list or any other list.
+    /// The caller must ensure that `node` is not currently linked in a list
     ///
     /// Inserting an already-linked node can corrupt list structure, create a
     /// cycle, or cause nodes to become unreachable through their original
     /// list.
-    pub unsafe fn push_tail(&self, node: &'a T) {
+    pub unsafe fn push_tail_unchecked(&self, node: &'a T) {
         // The inserted node becomes the new tail.
         node.next().0.set(LinkState::Tail);
 
@@ -233,6 +218,9 @@ impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
     /// Unlinks `node` if it is a member of this list.
     ///
     /// Returns `true` if the node was found and removed.
+    /// Unlinks `node` if it is a member of this list.
+    ///
+    /// Returns `true` if the node was found and removed.
     pub fn remove(&self, node: &'a T) -> bool {
         // This only rejects a node that is definitely unlinked. A linked node
         // might belong to another list, so membership must still be verified
@@ -246,7 +234,7 @@ impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
             None => return false,
         };
 
-        if same_node(head, node) {
+        if core::ptr::addr_eq(head, node) {
             self.pop_head();
             return true;
         }
@@ -254,7 +242,7 @@ impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
         let mut previous = head;
 
         while let LinkState::Next(current) = previous.next().0.get() {
-            if same_node(current, node) {
+            if core::ptr::addr_eq(current, node) {
                 match current.next().0.get() {
                     LinkState::Next(next) => {
                         // Remove a middle node by linking its predecessor
@@ -284,7 +272,6 @@ impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
 
         false
     }
-
     /// Returns an iterator from the head to the tail.
     pub fn iter(&self) -> ListIterator<'a, T> {
         ListIterator {

--- a/kernel/src/collections/list.rs
+++ b/kernel/src/collections/list.rs
@@ -6,6 +6,14 @@
 
 use core::cell::Cell;
 
+/// Compare two(possibly unsized) references by data address only, ignoring
+/// any pointer metadata such as vtable pointer
+fn same_node<T: ?Sized>(a: &T, b: &T) -> bool {
+    let a: *const T = a;
+    let b: *const T = b;
+    core::ptr::eq(a.cast::<()>(), b.cast::<()>())
+}
+
 pub struct ListLink<'a, T: 'a + ?Sized>(Cell<Option<&'a T>>);
 
 impl<'a, T: ?Sized> ListLink<'a, T> {
@@ -30,13 +38,13 @@ impl<'a, T: ?Sized + ListNode<'a, T>> Iterator for ListIterator<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
-        match self.cur {
-            Some(res) => {
-                self.cur = res.next().0.get();
-                Some(res)
-            }
-            None => None,
-        }
+        let cur = self.cur?;
+        self.cur = match cur.next().0.get() {
+            // A self-link marks the tail
+            Some(n) if same_node(n, cur) => None,
+            other => other,
+        };
+        Some(cur)
     }
 }
 
@@ -51,26 +59,80 @@ impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
         self.head.0.get()
     }
 
-    pub fn push_head(&self, node: &'a T) {
-        node.next().0.set(self.head.0.get());
-        self.head.0.set(Some(node));
+    /// Returns `Err(()) if the node is already in a list`
+    pub fn is_linked(node: &'a T) -> bool {
+        node.next().0.get().is_some()
     }
 
-    pub fn push_tail(&self, node: &'a T) {
-        node.next().0.set(None);
+    pub fn push_head(&self, node: &'a T) -> Result<(), ()> {
+        if Self::is_linked(node) {
+            return Err(());
+        }
+        match self.head.0.get() {
+            Some(h) => node.next().0.set(Some(h)),
+            // Empty list: `node` becomes the tail, so it links to itself
+            None => node.next().0.set(Some(node)),
+        }
+        self.head.0.set(Some(node));
+        Ok(())
+    }
+
+    pub fn push_tail(&self, node: &'a T) -> Result<(), ()> {
+        if Self::is_linked(node) {
+            return Err(());
+        }
+
+        node.next().0.set(Some(node));
         match self.iter().last() {
             Some(last) => last.next().0.set(Some(node)),
-            None => self.push_head(node),
+            None => self.head.0.set(Some(node)),
         }
+        Ok(())
     }
 
     pub fn pop_head(&self) -> Option<&'a T> {
-        let remove = self.head.0.get();
-        match remove {
-            Some(node) => self.head.0.set(node.next().0.get()),
-            None => self.head.0.set(None),
+        let node = self.head.0.get()?;
+        self.head.0.set(match node.next().0.get() {
+            Some(n) if same_node(n, node) => None,
+            other => other,
+        });
+        // Restoring the invariant for the returned node
+        node.next().0.set(None);
+        Some(node)
+    }
+
+    /// Unlinks `node` if it is a member of *this* list.
+    pub fn remove(&self, node: &'a T) -> bool {
+        if !Self::is_linked(node) {
+            return false;
         }
-        remove
+        let head = match self.head.0.get() {
+            Some(h) => h,
+            None => return false,
+        };
+        if same_node(head, node) {
+            self.pop_head();
+            return true;
+        }
+        let mut prev = head;
+        while let Some(cur) = {
+            match prev.next().0.get() {
+                Some(n) if same_node(n, prev) => None,
+                other => other,
+            }
+        } {
+            if same_node(cur, node) {
+                // If `node` was the tail, `prev` becomes the new tail.
+                prev.next().0.set(match cur.next().0.get() {
+                    Some(n) if same_node(n, cur) => Some(prev),
+                    other => other,
+                });
+                node.next().0.set(None);
+                return true;
+            }
+            prev = cur;
+        }
+        false
     }
 
     pub fn iter(&self) -> ListIterator<'a, T> {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds checks for duplicate in a linked list. The basic strategy for detecting a duplicate is to check if the node was linked before.
The `remove()` function was missing from the implementation of LinkedList so it was added in this pull request.


### Testing Strategy

This pull request was tested by @genan2003. 


### TODO or Help Wanted

This pull request still needs review.


### Checklist

- [x] Ran `make prepush`.


### PR Contents

#### Documentation

- [ ] Updated the relevant files in `/docs` and the [Book](https://github.com/tock/book).
- [x] No documentation updates are required.

#### AI Use

- [x] No AI was used in this PR.
- [ ] AI was used in this PR. I have read [Tock's AI policy](https://github.com/tock/tock/blob/master/.github/CONTRIBUTING.md) and have properly disclosed my AI use below.

<!-- Include details of AI use here, if you used any --!>
